### PR TITLE
Export computeEncodeType and extractPrimaryType under eip712 namespace

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,11 @@ import {
   parseCalldataHex,
   rawPreviewFromCalldata,
 } from "./calldata.js";
-import { formatEip712 } from "./eip712.js";
+import {
+  computeEncodeType,
+  extractPrimaryType,
+  formatEip712,
+} from "./eip712.js";
 import { warn } from "./utils.js";
 import type {
   Descriptor,
@@ -49,6 +53,12 @@ export {
   resolveCalldataDescriptor,
   resolveTypedDataDescriptor,
 } from "./resolver.js";
+
+/** EIP-712 utility helpers. */
+export const eip712 = {
+  computeEncodeType,
+  extractPrimaryType,
+};
 
 /**
  * Formats a single transaction's calldata into a human-readable {@link DisplayModel}.


### PR DESCRIPTION
Needed by the test runner.