### PR TITLE
Accept bytes-typed metadata constants in numeric param resolution

### DIFF
--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -351,7 +351,7 @@ export function tokenAmountMessage(
     threshold = resolved.value;
   } else if (resolved.type === "string") {
     threshold = parseBigInt(resolved.value);
-  } else if (resolved.type === "bytes-slice") {
+  } else if (resolved.type === "bytes" || resolved.type === "bytes-slice") {
     threshold = bytesToUnsignedBigInt(resolved.bytes);
   }
 
@@ -922,7 +922,7 @@ function resolveAmountParam(
   if (resolved?.type === "string") {
     return parseBigInt(resolved.value);
   }
-  if (resolved?.type === "bytes-slice") {
+  if (resolved?.type === "bytes" || resolved?.type === "bytes-slice") {
     return bytesToUnsignedBigInt(resolved.bytes);
   }
 
@@ -1193,7 +1193,7 @@ function resolveChainId(
     let resolvedN: bigint | undefined;
     if (resolved?.type === "uint" || resolved?.type === "int") {
       resolvedN = resolved.value;
-    } else if (resolved?.type === "bytes-slice") {
+    } else if (resolved?.type === "bytes" || resolved?.type === "bytes-slice") {
       resolvedN = bytesToUnsignedBigInt(resolved.bytes);
     }
 

--- a/test/registry-cases/aave-lpv2/aave-lpv2.spec.ts
+++ b/test/registry-cases/aave-lpv2/aave-lpv2.spec.ts
@@ -1,0 +1,142 @@
+/**
+ * Tests for Aave Lending Pool v2 descriptor:
+ * - repay: tokenAmount with threshold/message (max uint → "All"),
+ *   enum-formatted interest rate mode, addressName onBehalfOf
+ */
+
+import { describe, it, expect, assert } from "vitest";
+import { format, isFieldGroup } from "../../../src/index.js";
+import type { DisplayModel, ExternalDataProvider } from "../../../src/types.js";
+import { toChecksumAddress, hexToBytes } from "../../../src/utils.js";
+import { buildEmbeddedResolverOpts } from "../../utils.js";
+
+describe("Aave Lending Pool v2", () => {
+  const CHAIN_ID = 1;
+  const CONTRACT = "0x7d2768dE32b0b80b7a3454c06BdAc94A69DDc7A9";
+  const ON_BEHALF_OF = "0x2fec9b58d089447d3e5e50578b9f71321713a470";
+  const USDC = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
+
+  function buildOpts(externalDataProvider?: ExternalDataProvider) {
+    return buildEmbeddedResolverOpts(
+      __dirname,
+      {
+        calldataDescriptorFiles: [
+          {
+            chainId: CHAIN_ID,
+            address: CONTRACT,
+            file: "calldata-lpv2.json",
+          },
+        ],
+      },
+      externalDataProvider,
+    );
+  }
+
+  // =========================================================================
+  // repay
+  // =========================================================================
+  describe("repay", () => {
+    // repay(address asset, uint256 amount, uint256 rateMode, address onBehalfOf)
+    // Calldata extracted from an EIP-1559 mainnet tx to the Aave LPv2 contract:
+    //   asset       = USDC
+    //   amount      = max uint256  (matches $.metadata.constants.max → "All")
+    //   rateMode    = 2            (variable)
+    //   onBehalfOf  = 0x2fec…a470
+    const REPAY_CALLDATA =
+      "0x573ade81" +
+      "000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48" +
+      "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" +
+      "0000000000000000000000000000000000000000000000000000000000000002" +
+      "0000000000000000000000002fec9b58d089447d3e5e50578b9f71321713a470";
+
+    const resolveToken: ExternalDataProvider["resolveToken"] = async (
+      chainId,
+      tokenAddress,
+    ) => {
+      if (chainId === CHAIN_ID && tokenAddress === USDC) {
+        return { name: "USD Coin", symbol: "USDC", decimals: 6 };
+      }
+      return null;
+    };
+
+    const resolveLocalName: ExternalDataProvider["resolveLocalName"] = async (
+      address,
+    ) => {
+      if (address === ON_BEHALF_OF.toLowerCase()) {
+        return { name: "alice.eth", typeMatch: true };
+      }
+      return null;
+    };
+
+    it("renders 'All' when amount equals the max threshold constant", async () => {
+      const opts = buildOpts({ resolveToken, resolveLocalName });
+
+      const result: DisplayModel = await format(
+        {
+          chainId: CHAIN_ID,
+          to: CONTRACT,
+          data: REPAY_CALLDATA,
+        },
+        opts,
+      );
+
+      expect(result.intent).toBe("Repay loan");
+
+      assert(result.fields);
+      expect(result.fields).toHaveLength(3);
+
+      // Field 0: Amount to repay — amount == $.metadata.constants.max → "All"
+      const amountField = result.fields[0];
+      assert(!isFieldGroup(amountField));
+      expect(amountField.label).toBe("Amount to repay");
+      expect(amountField.value).toBe("All USDC");
+      expect(amountField.fieldType).toBe("uint");
+      expect(amountField.format).toBe("tokenAmount");
+      expect(amountField.tokenAddress).toBe(
+        toChecksumAddress(hexToBytes(USDC)),
+      );
+      expect(amountField.embeddedCalldata).toBeUndefined();
+      expect(amountField.rawAddress).toBeUndefined();
+      expect(amountField.warning).toBeUndefined();
+
+      // Field 1: Interest rate mode (enum, rateMode=2 → "variable")
+      const rateField = result.fields[1];
+      assert(!isFieldGroup(rateField));
+      expect(rateField.label).toBe("Interest rate mode");
+      expect(rateField.value).toBe("variable");
+      expect(rateField.fieldType).toBe("uint");
+      expect(rateField.format).toBe("enum");
+      expect(rateField.tokenAddress).toBeUndefined();
+      expect(rateField.embeddedCalldata).toBeUndefined();
+      expect(rateField.rawAddress).toBeUndefined();
+      expect(rateField.warning).toBeUndefined();
+
+      // Field 2: For debt holder (addressName, onBehalfOf → alice.eth)
+      const onBehalfOfField = result.fields[2];
+      assert(!isFieldGroup(onBehalfOfField));
+      expect(onBehalfOfField.label).toBe("For debt holder");
+      expect(onBehalfOfField.value).toBe("alice.eth");
+      expect(onBehalfOfField.fieldType).toBe("address");
+      expect(onBehalfOfField.format).toBe("addressName");
+      expect(onBehalfOfField.rawAddress).toBe(
+        toChecksumAddress(hexToBytes(ON_BEHALF_OF)),
+      );
+      expect(onBehalfOfField.tokenAddress).toBeUndefined();
+      expect(onBehalfOfField.embeddedCalldata).toBeUndefined();
+      expect(onBehalfOfField.warning).toBeUndefined();
+
+      // Metadata
+      assert(result.metadata);
+      expect(result.metadata.owner).toBe("Aave DAO");
+      expect(result.metadata.contractName).toBe("Lending Pool v2");
+      expect(result.metadata.info).toEqual({
+        url: "https://aave.com",
+        deploymentDate: "2020-11-30T09:25:48Z",
+      });
+
+      expect(result.interpolatedIntent).toBeUndefined();
+      expect(result.rawCalldataFallback).toBeUndefined();
+      expect(result.warnings).toBeUndefined();
+    });
+  });
+});

--- a/test/registry-cases/aave-lpv2/calldata-lpv2.json
+++ b/test/registry-cases/aave-lpv2/calldata-lpv2.json
@@ -1,0 +1,175 @@
+{
+  "$schema": "../../specs/erc7730-v2.schema.json",
+  "context": {
+    "$id": "Lending Pool v2",
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0x7d2768dE32b0b80b7a3454c06BdAc94A69DDc7A9"
+        },
+        {
+          "chainId": 137,
+          "address": "0x8dFf5E27EA6b7AC08EbFdf9eB090F32ee9a30fcf"
+        },
+        {
+          "chainId": 43114,
+          "address": "0x4F01AeD16D97E3aB5ab2B501154DC9bb0F1A5A2C"
+        }
+      ]
+    }
+  },
+  "metadata": {
+    "owner": "Aave DAO",
+    "info": {
+      "url": "https://aave.com",
+      "deploymentDate": "2020-11-30T09:25:48Z"
+    },
+    "enums": { "interestRateMode": { "1": "stable", "2": "variable" } },
+    "constants": {
+      "max": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+    },
+    "contractName": "Lending Pool v2"
+  },
+  "display": {
+    "formats": {
+      "repay(address asset, uint256 amount, uint256 rateMode, address onBehalfOf)": {
+        "$id": "repay",
+        "intent": "Repay loan",
+        "fields": [
+          {
+            "path": "amount",
+            "format": "tokenAmount",
+            "label": "Amount to repay",
+            "params": {
+              "tokenPath": "asset",
+              "threshold": "$.metadata.constants.max",
+              "message": "All"
+            },
+            "visible": "always"
+          },
+          {
+            "path": "rateMode",
+            "format": "enum",
+            "label": "Interest rate mode",
+            "params": { "$ref": "$.metadata.enums.interestRateMode" },
+            "visible": "always"
+          },
+          {
+            "path": "onBehalfOf",
+            "format": "addressName",
+            "label": "For debt holder",
+            "params": { "types": ["eoa"], "sources": ["local", "ens"] },
+            "visible": "always"
+          }
+        ]
+      },
+      "setUserUseReserveAsCollateral(address asset, bool useAsCollateral)": {
+        "intent": "Manage collateral",
+        "fields": [
+          {
+            "path": "asset",
+            "format": "addressName",
+            "label": "For asset",
+            "params": { "types": ["token"], "sources": ["local", "ens"] },
+            "visible": "always"
+          },
+          {
+            "path": "useAsCollateral",
+            "format": "raw",
+            "label": "Enable as collateral",
+            "visible": "always"
+          }
+        ]
+      },
+      "withdraw(address asset, uint256 amount, address to)": {
+        "intent": "Withdraw",
+        "fields": [
+          {
+            "path": "amount",
+            "format": "tokenAmount",
+            "label": "Amount to withdraw",
+            "params": {
+              "tokenPath": "asset",
+              "threshold": "$.metadata.constants.max",
+              "message": "Max"
+            },
+            "visible": "always"
+          },
+          {
+            "path": "to",
+            "format": "addressName",
+            "label": "To recipient",
+            "params": { "types": ["eoa"], "sources": ["local", "ens"] },
+            "visible": "always"
+          }
+        ]
+      },
+      "swapBorrowRateMode(address asset, uint256 rateMode)": {
+        "intent": "Swap to variable",
+        "fields": [
+          {
+            "path": "asset",
+            "format": "addressName",
+            "label": "For asset",
+            "params": { "types": ["token"], "sources": ["local", "ens"] },
+            "visible": "always"
+          },
+          {
+            "path": "rateMode",
+            "format": "enum",
+            "label": "Current rate mode",
+            "params": { "$ref": "$.metadata.enums.interestRateMode" },
+            "visible": "always"
+          }
+        ]
+      },
+      "borrow(address asset, uint256 amount, uint256 interestRateMode, uint16 referralCode, address onBehalfOf)": {
+        "intent": "Borrow",
+        "fields": [
+          {
+            "path": "amount",
+            "format": "tokenAmount",
+            "label": "Amount to borrow",
+            "params": { "tokenPath": "asset" },
+            "visible": "always"
+          },
+          {
+            "path": "interestRateMode",
+            "format": "enum",
+            "label": "Interest Rate mode",
+            "params": { "$ref": "$.metadata.enums.interestRateMode" },
+            "visible": "always"
+          },
+          {
+            "path": "onBehalfOf",
+            "format": "addressName",
+            "label": "Debtor",
+            "params": { "types": ["eoa"], "sources": ["local", "ens"] },
+            "visible": "always"
+          }
+        ]
+      },
+      "deposit(address asset, uint256 amount, address onBehalfOf, uint16 referralCode)": {
+        "$id": "deposit",
+        "intent": "Supply",
+        "fields": [
+          {
+            "path": "amount",
+            "format": "tokenAmount",
+            "label": "Amount to supply",
+            "params": { "tokenPath": "asset" },
+            "visible": "always"
+          },
+          {
+            "path": "onBehalfOf",
+            "format": "addressName",
+            "label": "Collateral recipient",
+            "params": { "types": ["eoa"], "sources": ["local", "ens"] },
+            "visible": "always"
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `tokenAmountMessage`, `resolveAmountParam`, and `resolveChainId` branched on `uint/int/string/bytes-slice` but missed `bytes`.
- Hex-string metadata constants (e.g. `$.metadata.constants.max`) are wrapped by `toArgumentValue` as `{ type: "bytes" }` and silently fell through.
- Symptom: Aave LPv2 `repay` with `amount = max uint256` rendered the raw integer instead of the descriptor's `"All"` threshold message.
- Adds a regression test using calldata from a real mainnet `repay` tx.