### PR TITLE
Remove thousand separators from numeric formatting

### DIFF
--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -22,7 +22,6 @@ import {
   resolveMetadataValue,
 } from "./descriptor.js";
 import {
-  addThousandSeparators,
   bytesToUnsignedBigInt,
   bytesToHex,
   formatAmountWithDecimals,
@@ -145,7 +144,7 @@ export function renderRaw(value: ArgumentValue): string {
       return toChecksumAddress(value.bytes);
     case "uint":
     case "int":
-      return addThousandSeparators(value.value.toString());
+      return value.value.toString();
     case "bool":
       return value.value.toString();
     case "string":

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -96,33 +96,20 @@ export function toChecksumAddress(bytes: Uint8Array): string {
   return result;
 }
 
-/** Add thousand separators to a numeric string. */
-export function addThousandSeparators(value: string): string {
-  const chars = value.split("").reverse();
-  const result: string[] = [];
-  for (let i = 0; i < chars.length; i++) {
-    if (i > 0 && i % 3 === 0) {
-      result.push(",");
-    }
-    result.push(chars[i]);
-  }
-  return result.reverse().join("");
-}
-
 /** Format a bigint amount with decimal places. */
 export function formatAmountWithDecimals(
   amount: bigint,
   decimals: number,
 ): string {
   if (decimals === 0) {
-    return addThousandSeparators(amount.toString());
+    return amount.toString();
   }
 
   const factor = 10n ** BigInt(decimals);
   const integer = amount / factor;
   const remainder = amount % factor;
 
-  const integerPart = addThousandSeparators(integer.toString());
+  const integerPart = integer.toString();
   if (remainder === 0n) {
     return integerPart;
   }

--- a/test/erc7730-test-cases/example-eip712.spec.ts
+++ b/test/erc7730-test-cases/example-eip712.spec.ts
@@ -166,7 +166,7 @@ describe("example-eip712.json — PermitSingle", () => {
     const amountField = result.fields[1];
     assert(!isFieldGroup(amountField));
     expect(amountField.label).toBe("Amount allowance");
-    expect(amountField.value).toBe("1,000,000");
+    expect(amountField.value).toBe("1000000");
     expect(amountField.fieldType).toBe("uint");
     expect(amountField.format).toBe("tokenAmount");
     expect(amountField.tokenAddress).toBe(

--- a/test/erc7730-test-cases/example-main.spec.ts
+++ b/test/erc7730-test-cases/example-main.spec.ts
@@ -10,11 +10,7 @@ import type {
   ExternalDataProvider,
   FormatOptions,
 } from "../../src/types.js";
-import {
-  addThousandSeparators,
-  hexToBytes,
-  toChecksumAddress,
-} from "../../src/utils.js";
+import { hexToBytes, toChecksumAddress } from "../../src/utils.js";
 import { buildEmbeddedResolverOpts } from "../utils.js";
 
 // USDT on mainnet (matches example-main.json deployment)
@@ -214,9 +210,7 @@ describe("example-main.json — transfer(address to, uint256 value)", () => {
     const amountField = result.fields[1];
     assert(!isFieldGroup(amountField));
     expect(amountField.label).toBe("Amount");
-    expect(amountField.value).toBe(
-      addThousandSeparators(TRANSFER_AMOUNT.toString()),
-    );
+    expect(amountField.value).toBe(TRANSFER_AMOUNT.toString());
     expect(amountField.fieldType).toBe("uint");
     expect(amountField.format).toBe("tokenAmount");
     expect(amountField.tokenAddress).toBe(
@@ -229,7 +223,7 @@ describe("example-main.json — transfer(address to, uint256 value)", () => {
 
     expect(result.intent).toBe("Send");
     expect(result.interpolatedIntent).toBe(
-      `Send ${addThousandSeparators(TRANSFER_AMOUNT.toString())} to ${RECIPIENT_LOCAL_NAME}`,
+      `Send ${TRANSFER_AMOUNT.toString()} to ${RECIPIENT_LOCAL_NAME}`,
     );
 
     assert(result.metadata);

--- a/test/formatters.spec.ts
+++ b/test/formatters.spec.ts
@@ -75,12 +75,12 @@ describe("renderRaw", () => {
     );
   });
 
-  it("formats uint with thousand separators", () => {
-    expect(renderRaw(uint(1000000n))).toBe("1,000,000");
+  it("formats uint as decimal string", () => {
+    expect(renderRaw(uint(1000000n))).toBe("1000000");
   });
 
-  it("formats int with thousand separators", () => {
-    expect(renderRaw(int(123456n))).toBe("123,456");
+  it("formats int as decimal string", () => {
+    expect(renderRaw(int(123456n))).toBe("123456");
   });
 
   it("formats bool", () => {
@@ -156,7 +156,7 @@ describe("formatNativeAmount", () => {
 
   it("falls back to raw with UNKNOWN_CHAIN when provider is absent", async () => {
     const result = await formatNativeAmount(uint(10n ** 18n), 1);
-    expect(result.rendered).toBe("1,000,000,000,000,000,000");
+    expect(result.rendered).toBe("1000000000000000000");
     expect(result.warning?.code).toBe("UNKNOWN_CHAIN");
   });
 
@@ -166,7 +166,7 @@ describe("formatNativeAmount", () => {
       undefined,
       provider,
     );
-    expect(result.rendered).toBe("1,000,000,000,000,000,000");
+    expect(result.rendered).toBe("1000000000000000000");
     expect(result.warning?.code).toBe("UNKNOWN_CHAIN");
   });
 });
@@ -400,7 +400,7 @@ describe("formatTokenAmount", () => {
       1,
       undefined,
     );
-    expect(result.rendered).toBe("1,000,000");
+    expect(result.rendered).toBe("1000000");
     expect(result.warning?.code).toBe("FORMAT_PARAM_RESOLUTION_ERROR");
   });
 
@@ -417,7 +417,7 @@ describe("formatTokenAmount", () => {
       undefined,
       nullProvider,
     );
-    expect(result.rendered).toBe("1,000,000");
+    expect(result.rendered).toBe("1000000");
     expect(result.warning?.code).toBe("UNKNOWN_TOKEN");
     expect(result.tokenAddress).toBe(
       "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
@@ -513,7 +513,7 @@ describe("formatTokenAmount", () => {
       undefined,
       provider,
     );
-    expect(result.rendered).toBe("1,000,000");
+    expect(result.rendered).toBe("1000000");
     expect(result.warning?.code).toBe("FORMAT_PARAM_RESOLUTION_ERROR");
   });
 });
@@ -633,7 +633,7 @@ describe("formatTokenAmount with metadata token", () => {
       1,
       incompleteMeta,
     );
-    expect(result.rendered).toBe("1,000,000");
+    expect(result.rendered).toBe("1000000");
     expect(result.warning?.code).toBe("FORMAT_PARAM_RESOLUTION_ERROR");
   });
 
@@ -938,7 +938,7 @@ describe("formatNftName", () => {
 
   it("falls back to raw when collection address is missing", async () => {
     const result = await formatNftName({}, uint(1036n), noopResolvePath, 1);
-    expect(result.rendered).toBe("1,036");
+    expect(result.rendered).toBe("1036");
     expect(result.warning?.code).toBe("FORMAT_PARAM_RESOLUTION_ERROR");
   });
 
@@ -952,7 +952,7 @@ describe("formatNftName", () => {
       noopResolvePath,
       undefined,
     );
-    expect(result.rendered).toBe("1,036");
+    expect(result.rendered).toBe("1036");
     expect(result.warning?.code).toBe("CONTAINER_MISSING_CHAIN_ID");
   });
 
@@ -970,7 +970,7 @@ describe("formatNftName", () => {
       1,
       provider,
     );
-    expect(result.rendered).toBe("1,036");
+    expect(result.rendered).toBe("1036");
     expect(result.warning?.code).toBe("UNKNOWN_NFT_COLLECTION");
   });
 
@@ -988,7 +988,7 @@ describe("formatNftName", () => {
       1,
       provider,
     );
-    expect(result.rendered).toBe("1,036");
+    expect(result.rendered).toBe("1036");
     expect(result.warning?.code).toBe("UNKNOWN_NFT_COLLECTION");
   });
 
@@ -1060,7 +1060,7 @@ describe("formatDate", () => {
 
   it("falls back to raw when encoding is missing", async () => {
     const result = await formatDate(uint(1705312800n), {}, 1);
-    expect(result.rendered).toBe("1,705,312,800");
+    expect(result.rendered).toBe("1705312800");
     expect(result.warning?.code).toBe("UNKNOWN_ENCODING");
   });
 
@@ -1116,7 +1116,7 @@ describe("formatDate", () => {
       1,
       provider,
     );
-    expect(result.rendered).toBe("19,332,140");
+    expect(result.rendered).toBe("19332140");
     expect(result.warning?.code).toBe("UNKNOWN_BLOCK");
   });
 
@@ -1130,13 +1130,13 @@ describe("formatDate", () => {
       1,
       provider,
     );
-    expect(result.rendered).toBe("19,332,140");
+    expect(result.rendered).toBe("19332140");
     expect(result.warning?.code).toBe("UNKNOWN_BLOCK");
   });
 
   it("returns UNKNOWN_BLOCK when no provider for blockheight", async () => {
     const result = await formatDate(uint(19332140n), blockheightOpts, 1);
-    expect(result.rendered).toBe("19,332,140");
+    expect(result.rendered).toBe("19332140");
     expect(result.warning?.code).toBe("UNKNOWN_BLOCK");
   });
 });

--- a/test/registry-cases/1inch/1inch.spec.ts
+++ b/test/registry-cases/1inch/1inch.spec.ts
@@ -117,7 +117,7 @@ describe("1inch AggregationRouterV6", () => {
       const sendField = result.fields[0];
       assert(!isFieldGroup(sendField));
       expect(sendField.label).toBe("Amount to Send");
-      expect(sendField.value).toBe("500,000,000,000,000 CHUPA");
+      expect(sendField.value).toBe("500000000000000 CHUPA");
       expect(sendField.fieldType).toBe("uint");
       expect(sendField.format).toBe("tokenAmount");
       expect(sendField.tokenAddress).toBe(
@@ -239,7 +239,7 @@ describe("1inch AggregationRouterV6", () => {
       const sendField = result.fields[0];
       assert(!isFieldGroup(sendField));
       expect(sendField.label).toBe("Amount to Send");
-      expect(sendField.value).toBe("1,000 USDC");
+      expect(sendField.value).toBe("1000 USDC");
       expect(sendField.fieldType).toBe("uint");
       expect(sendField.format).toBe("tokenAmount");
       expect(sendField.tokenAddress).toBe(toChecksumAddress(hexToBytes(USDC)));

--- a/test/registry-cases/paraswap/paraswap.spec.ts
+++ b/test/registry-cases/paraswap/paraswap.spec.ts
@@ -144,7 +144,7 @@ describe("Paraswap AugustusSwapper v6.2", () => {
       const sendField = result.fields[1];
       assert(!isFieldGroup(sendField));
       expect(sendField.label).toBe("Maximum to Send");
-      expect(sendField.value).toBe("2,000,000,000,000 USDC");
+      expect(sendField.value).toBe("2000000000000 USDC");
       expect(sendField.fieldType).toBe("uint");
       expect(sendField.format).toBe("tokenAmount");
       expect(sendField.tokenAddress).toBe(toChecksumAddress(hexToBytes(USDC)));
@@ -374,7 +374,7 @@ describe("Paraswap AugustusSwapper v6.2", () => {
       const sendField = result.fields[0];
       assert(!isFieldGroup(sendField));
       expect(sendField.label).toBe("Amount to Send");
-      expect(sendField.value).toBe("6,781.622338330348265721 CRV");
+      expect(sendField.value).toBe("6781.622338330348265721 CRV");
       expect(sendField.fieldType).toBe("uint");
       expect(sendField.format).toBe("tokenAmount");
       expect(sendField.tokenAddress).toBe(toChecksumAddress(hexToBytes(CRV)));
@@ -386,7 +386,7 @@ describe("Paraswap AugustusSwapper v6.2", () => {
       const receiveField = result.fields[1];
       assert(!isFieldGroup(receiveField));
       expect(receiveField.label).toBe("Minimum to Receive");
-      expect(receiveField.value).toBe("1,550.108421 USDC");
+      expect(receiveField.value).toBe("1550.108421 USDC");
       expect(receiveField.fieldType).toBe("uint");
       expect(receiveField.format).toBe("tokenAmount");
       expect(receiveField.tokenAddress).toBe(


### PR DESCRIPTION
## Summary
- ERC-7730 does not require thousand separators; remove the `addThousandSeparators` helper and render `uint`/`int` raw values and token/native amounts as plain decimal strings
- Update all test expectations across formatter unit tests and registry/spec test cases to match the new output