### PR TITLE
Render date format as RFC 3339 with Z suffix

### DIFF
--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -621,7 +621,7 @@ export async function formatDate(
 }
 
 /**
- * Format a Unix timestamp (seconds) as a UTC date string.
+ * Format a Unix timestamp (seconds) as an RFC 3339 date string in UTC.
  */
 export function formatTimestamp(seconds: bigint): RenderFieldResult {
   const date = new Date(Number(seconds) * 1000);
@@ -632,7 +632,7 @@ export function formatTimestamp(seconds: bigint): RenderFieldResult {
   const minutes = String(date.getUTCMinutes()).padStart(2, "0");
   const secs = String(date.getUTCSeconds()).padStart(2, "0");
   return {
-    rendered: `${year}-${month}-${day} ${hours}:${minutes}:${secs} UTC`,
+    rendered: `${year}-${month}-${day} ${hours}:${minutes}:${secs}Z`,
   };
 }
 

--- a/test/erc7730-test-cases/example-eip712.spec.ts
+++ b/test/erc7730-test-cases/example-eip712.spec.ts
@@ -138,7 +138,7 @@ describe("example-eip712.json — PermitSingle", () => {
     const expirationField = result.fields[2];
     assert(!isFieldGroup(expirationField));
     expect(expirationField.label).toBe("Approval expires");
-    expect(expirationField.value).toBe("2025-01-01 00:00:00 UTC");
+    expect(expirationField.value).toBe("2025-01-01 00:00:00Z");
     expect(expirationField.fieldType).toBe("uint");
     expect(expirationField.format).toBe("date");
     expect(expirationField.rawAddress).toBeUndefined();
@@ -381,7 +381,7 @@ describe("example-eip712.json — PermitBatch", () => {
 
     const exp0 = group.fields[1];
     expect(exp0.label).toBe("Approval expires");
-    expect(exp0.value).toBe("2025-01-01 00:00:00 UTC");
+    expect(exp0.value).toBe("2025-01-01 00:00:00Z");
     expect(exp0.fieldType).toBe("uint");
     expect(exp0.format).toBe("date");
     expect(exp0.rawAddress).toBeUndefined();
@@ -404,7 +404,7 @@ describe("example-eip712.json — PermitBatch", () => {
 
     const exp1 = group.fields[3];
     expect(exp1.label).toBe("Approval expires");
-    expect(exp1.value).toBe("2026-01-01 00:00:00 UTC");
+    expect(exp1.value).toBe("2026-01-01 00:00:00Z");
     expect(exp1.fieldType).toBe("uint");
     expect(exp1.format).toBe("date");
     expect(exp1.rawAddress).toBeUndefined();

--- a/test/formatters.spec.ts
+++ b/test/formatters.spec.ts
@@ -1023,18 +1023,18 @@ describe("formatTimestamp", () => {
   it("formats Unix epoch as UTC date", () => {
     // 2024-01-15 10:00:00 UTC = 1705312800
     const result = formatTimestamp(1705312800n);
-    expect(result.rendered).toBe("2024-01-15 10:00:00 UTC");
+    expect(result.rendered).toBe("2024-01-15 10:00:00Z");
   });
 
   it("formats epoch 0", () => {
     const result = formatTimestamp(0n);
-    expect(result.rendered).toBe("1970-01-01 00:00:00 UTC");
+    expect(result.rendered).toBe("1970-01-01 00:00:00Z");
   });
 
   it("pads single-digit months and days", () => {
     // 2024-03-05 08:01:02 UTC = 1709625662
     const result = formatTimestamp(1709625662n);
-    expect(result.rendered).toBe("2024-03-05 08:01:02 UTC");
+    expect(result.rendered).toBe("2024-03-05 08:01:02Z");
   });
 });
 
@@ -1048,13 +1048,13 @@ describe("formatDate", () => {
 
   it("formats a uint value as date with encoding=timestamp", async () => {
     const result = await formatDate(uint(1705312800n), timestampOpts, 1);
-    expect(result.rendered).toBe("2024-01-15 10:00:00 UTC");
+    expect(result.rendered).toBe("2024-01-15 10:00:00Z");
     expect(result.warning).toBeUndefined();
   });
 
   it("formats an int value as date with encoding=timestamp", async () => {
     const result = await formatDate(int(1705312800n), timestampOpts, 1);
-    expect(result.rendered).toBe("2024-01-15 10:00:00 UTC");
+    expect(result.rendered).toBe("2024-01-15 10:00:00Z");
     expect(result.warning).toBeUndefined();
   });
 
@@ -1079,7 +1079,7 @@ describe("formatDate", () => {
       1,
       provider,
     );
-    expect(result.rendered).toBe("2024-02-29 07:27:12 UTC");
+    expect(result.rendered).toBe("2024-02-29 07:27:12Z");
     expect(result.warning).toBeUndefined();
   });
 
@@ -1093,7 +1093,7 @@ describe("formatDate", () => {
       1,
       provider,
     );
-    expect(result.rendered).toBe("2024-02-29 07:27:12 UTC");
+    expect(result.rendered).toBe("2024-02-29 07:27:12Z");
     expect(result.warning).toBeUndefined();
   });
 
@@ -1995,7 +1995,7 @@ describe("renderField", () => {
       1,
       undefined,
     );
-    expect(result.rendered).toBe("1970-01-01 00:00:00 UTC");
+    expect(result.rendered).toBe("1970-01-01 00:00:00Z");
   });
 
   it("dispatches 'enum' format", async () => {

--- a/test/registry-cases/1inch/1inch.spec.ts
+++ b/test/registry-cases/1inch/1inch.spec.ts
@@ -279,7 +279,7 @@ describe("1inch AggregationRouterV6", () => {
       const expirationField = result.fields[3];
       assert(!isFieldGroup(expirationField));
       expect(expirationField.label).toBe("Expiration time");
-      expect(expirationField.value).toBe("2023-11-14 22:13:20 UTC");
+      expect(expirationField.value).toBe("2023-11-14 22:13:20Z");
       expect(expirationField.fieldType).toBe("uint");
       expect(expirationField.format).toBe("date");
       expect(expirationField.tokenAddress).toBeUndefined();


### PR DESCRIPTION
## Summary
- Replace ` UTC` suffix with `Z` in `formatTimestamp` so date output is RFC 3339-compliant (space-separated variant per §5.6)
- Update test assertions in `formatters.spec.ts`, `example-eip712.spec.ts`, and `1inch.spec.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)