### PR TITLE
Resolve $.metadata.* references in unit format base param

### DIFF
--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -93,7 +93,7 @@ export async function renderField(
     case "duration":
       return formatDuration(value);
     case "unit":
-      return formatUnit(value, fieldOptions);
+      return formatUnit(value, fieldOptions, metadata);
     case "enum":
       return formatEnum(fieldOptions, value, metadata);
     case "chainId":
@@ -673,12 +673,13 @@ const SI_PREFIXES: [bigint, string][] = [
 export function formatUnit(
   value: ArgumentValue,
   fieldOptions: FieldFormatOptions,
+  metadata: DescriptorMetadata | undefined,
 ): RenderFieldResult {
   if (value.type !== "uint" && value.type !== "int")
     return typeMismatch(value, "uint or int", "unit");
 
   const params = fieldOptions.params ?? {};
-  const base = params.base ?? "";
+  const base = resolveUnitBase(params.base, metadata);
   const decimals = params.decimals ?? 0;
   const prefix = params.prefix === true;
 
@@ -704,6 +705,20 @@ export function formatUnit(
   }
 
   return { rendered: `${formatted}${base}` };
+}
+
+/**
+ * The `base` param is either a literal unit symbol ("ETH", "%") or a
+ * `$.metadata.*` reference pointing at a string constant.
+ */
+function resolveUnitBase(
+  spec: string | undefined,
+  metadata: DescriptorMetadata | undefined,
+): string {
+  if (!spec) return "";
+  if (!spec.startsWith("$.metadata.")) return spec;
+  const resolved = resolveMetadataValue(metadata, spec);
+  return typeof resolved === "string" ? resolved : "";
 }
 
 function bigintLog10(n: bigint): number {

--- a/test/formatters.spec.ts
+++ b/test/formatters.spec.ts
@@ -1188,53 +1188,98 @@ describe("formatDuration", () => {
 
 describe("formatUnit", () => {
   it("formats integer with base unit (no decimals)", () => {
-    const result = formatUnit(uint(10n), { params: { base: "h" } });
+    const result = formatUnit(uint(10n), { params: { base: "h" } }, undefined);
     expect(result.rendered).toBe("10h");
   });
 
   it("formats with decimals", () => {
-    const result = formatUnit(uint(15n), {
-      params: { base: "d", decimals: 1 },
-    });
+    const result = formatUnit(
+      uint(15n),
+      { params: { base: "d", decimals: 1 } },
+      undefined,
+    );
     expect(result.rendered).toBe("1.5d");
   });
 
   it("formats percentage with decimals", () => {
-    const result = formatUnit(uint(5000n), {
-      params: { base: "%", decimals: 2 },
-    });
+    const result = formatUnit(
+      uint(5000n),
+      { params: { base: "%", decimals: 2 } },
+      undefined,
+    );
     expect(result.rendered).toBe("50%");
   });
 
   it("formats with SI prefix", () => {
-    const result = formatUnit(uint(36000n), {
-      params: { base: "s", prefix: true },
-    });
+    const result = formatUnit(
+      uint(36000n),
+      { params: { base: "s", prefix: true } },
+      undefined,
+    );
     expect(result.rendered).toBe("36ks");
   });
 
   it("formats with SI prefix and decimals", () => {
-    const result = formatUnit(uint(1500000n), {
-      params: { base: "W", decimals: 3, prefix: true },
-    });
+    const result = formatUnit(
+      uint(1500000n),
+      { params: { base: "W", decimals: 3, prefix: true } },
+      undefined,
+    );
     expect(result.rendered).toBe("1.5kW");
   });
 
   it("falls back to no prefix when value is too small", () => {
-    const result = formatUnit(uint(500n), {
-      params: { base: "s", prefix: true },
-    });
+    const result = formatUnit(
+      uint(500n),
+      { params: { base: "s", prefix: true } },
+      undefined,
+    );
     expect(result.rendered).toBe("500s");
   });
 
   it("returns type mismatch for non-numeric values", () => {
-    const result = formatUnit(str("hello"), { params: { base: "m" } });
+    const result = formatUnit(
+      str("hello"),
+      { params: { base: "m" } },
+      undefined,
+    );
     expect(result.warning?.code).toBe("ARGUMENT_TYPE_MISMATCH");
   });
 
   it("defaults decimals to 0 and base to empty", () => {
-    const result = formatUnit(uint(42n), {});
+    const result = formatUnit(uint(42n), {}, undefined);
     expect(result.rendered).toBe("42");
+  });
+
+  it("resolves a metadata-path base", () => {
+    const metadata: DescriptorMetadata = {
+      constants: { stakingTokenTicker: "POL" },
+    };
+    const result = formatUnit(
+      uint(100n * 10n ** 18n),
+      {
+        params: {
+          base: "$.metadata.constants.stakingTokenTicker",
+          decimals: 18,
+        },
+      },
+      metadata,
+    );
+    expect(result.rendered).toBe("100POL");
+    expect(result.warning).toBeUndefined();
+  });
+
+  it("falls back to empty base when the metadata path does not resolve to a string", () => {
+    const metadata: DescriptorMetadata = {
+      constants: { stakingTokenTicker: 42 },
+    };
+    const result = formatUnit(
+      uint(10n),
+      { params: { base: "$.metadata.constants.stakingTokenTicker" } },
+      metadata,
+    );
+    expect(result.rendered).toBe("10");
+    expect(result.warning).toBeUndefined();
   });
 });
 

--- a/test/registry-cases/yieldxyz/calldata-yieldxyz-pol-validator.json
+++ b/test/registry-cases/yieldxyz/calldata-yieldxyz-pol-validator.json
@@ -1,0 +1,142 @@
+{
+  "$schema": "../../specs/erc7730-v2.schema.json",
+  "metadata": {
+    "owner": "Yield.xyz",
+    "info": { "url": "https://yield.xyz/" },
+    "constants": { "stakingTokenTicker": "POL" },
+    "contractName": "YieldxyzPolValidator"
+  },
+  "context": {
+    "$id": "YieldxyzPolValidator",
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0xb929b89153fc2eed442e81e5a1add4e2fa39028f"
+        },
+        {
+          "chainId": 1,
+          "address": "0x56d783Ca8e0b998C57a428Bf1c26A8baca50524e"
+        },
+        {
+          "chainId": 1,
+          "address": "0x857679d69fe50e7b722f94acd2629d80c355163d"
+        },
+        {
+          "chainId": 1,
+          "address": "0xF30Cf4ed712D3734161fDAab5B1DBb49Fd2D0E5c"
+        },
+        {
+          "chainId": 1,
+          "address": "0x5A10DE50160126A5F936506BD342C541Ac44e943"
+        },
+        {
+          "chainId": 1,
+          "address": "0x35B1CA0F398905Cf752e6FE122b51c88022FCa32"
+        },
+        {
+          "chainId": 1,
+          "address": "0xD9E6987D77bf2c6d0647b8181fd68A259f838C36"
+        },
+        {
+          "chainId": 1,
+          "address": "0xD14a87025109013B0a2354a775cB335F926Af65A"
+        },
+        {
+          "chainId": 1,
+          "address": "0xa6e768fEf2D1aF36c0cfdb276422E7881a83e951"
+        },
+        {
+          "chainId": 1,
+          "address": "0x467585AaEa860F9D8B3B43bb994E4Da8A93788a7"
+        },
+        {
+          "chainId": 1,
+          "address": "0x06998Af8f39Ff8630d1FB515D22781DA4DC2CA71"
+        },
+        {
+          "chainId": 1,
+          "address": "0xC7757805B983eE1b6272c1840c18e66837dE858E"
+        },
+        {
+          "chainId": 1,
+          "address": "0xE3E9Ba8c8C696f8537cF16b23EDDf118bbD7f21F"
+        },
+        {
+          "chainId": 1,
+          "address": "0x875e901465A639f2E71fcfC10F426eD32F5A909a"
+        },
+        {
+          "chainId": 1,
+          "address": "0x2905B3387c9550Ea57fa3EE7d4b7E5Abf3acD3d2"
+        },
+        {
+          "chainId": 1,
+          "address": "0x15C2b3AdcA66E26B6F230b4023f52a285b7f9995"
+        },
+        {
+          "chainId": 1,
+          "address": "0x2EA3c215daeaCc1C90b51443aB5D08a9ad816138"
+        }
+      ]
+    }
+  },
+  "display": {
+    "formats": {
+      "buyVoucherPOL(uint256 _amount, uint256 _minSharesToMint)": {
+        "intent": "Stake POL",
+        "fields": [
+          {
+            "path": "#._amount",
+            "label": "Stake amount",
+            "format": "unit",
+            "params": {
+              "base": "$.metadata.constants.stakingTokenTicker",
+              "decimals": 18
+            },
+            "visible": "always"
+          },
+          {
+            "path": "#._minSharesToMint",
+            "label": "Min shares",
+            "format": "raw",
+            "visible": "always"
+          }
+        ]
+      },
+      "sellVoucher_newPOL(uint256 claimAmount, uint256 maximumSharesToBurn)": {
+        "intent": "Unstake POL",
+        "fields": [
+          {
+            "path": "#.claimAmount",
+            "label": "Claim amount",
+            "format": "unit",
+            "params": {
+              "base": "$.metadata.constants.stakingTokenTicker",
+              "decimals": 18
+            },
+            "visible": "always"
+          },
+          {
+            "path": "#.maximumSharesToBurn",
+            "label": "Max shares",
+            "format": "raw",
+            "visible": "always"
+          }
+        ]
+      },
+      "unstakeClaimTokens_newPOL(uint256 unbondNonce)": {
+        "intent": "Claim unstaked POL",
+        "fields": [
+          {
+            "path": "#.unbondNonce",
+            "label": "Unbond nonce",
+            "format": "raw",
+            "visible": "always"
+          }
+        ]
+      },
+      "withdrawRewardsPOL()": { "intent": "Withdraw POL rewards", "fields": [] }
+    }
+  }
+}

--- a/test/registry-cases/yieldxyz/yieldxyz.spec.ts
+++ b/test/registry-cases/yieldxyz/yieldxyz.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * Tests for Yield.xyz POL Validator descriptor:
+ * - buyVoucherPOL: unit format with $.metadata.constants base interpolation
+ */
+
+import { describe, it, expect, assert } from "vitest";
+import { format, isFieldGroup } from "../../../src/index.js";
+import type { DisplayModel } from "../../../src/types.js";
+import { bytesToHex, selectorForSignature } from "../../../src/utils.js";
+import { buildEmbeddedResolverOpts } from "../../utils.js";
+
+describe("Yield.xyz POL Validator", () => {
+  const CHAIN_ID = 1;
+  const CONTRACT = "0xb929b89153fc2eed442e81e5a1add4e2fa39028f";
+
+  function buildOpts() {
+    return buildEmbeddedResolverOpts(__dirname, {
+      calldataDescriptorFiles: [
+        {
+          chainId: CHAIN_ID,
+          address: CONTRACT,
+          file: "calldata-yieldxyz-pol-validator.json",
+        },
+      ],
+    });
+  }
+
+  // =========================================================================
+  // buyVoucherPOL
+  // =========================================================================
+  describe("buyVoucherPOL", () => {
+    // buyVoucherPOL(uint256 _amount, uint256 _minSharesToMint)
+    //   _amount           = 100 * 10^18  (100 POL)
+    //   _minSharesToMint  = 12345
+    const SELECTOR = bytesToHex(
+      selectorForSignature("buyVoucherPOL(uint256,uint256)"),
+    );
+
+    const BUY_VOUCHER_CALLDATA =
+      SELECTOR +
+      "0000000000000000000000000000000000000000000000056bc75e2d63100000" + // _amount = 100e18
+      "0000000000000000000000000000000000000000000000000000000000003039"; // _minSharesToMint = 12345
+
+    it("renders POL stake amount with constant-based unit ticker", async () => {
+      const opts = buildOpts();
+
+      const result: DisplayModel = await format(
+        {
+          chainId: CHAIN_ID,
+          to: CONTRACT,
+          data: BUY_VOUCHER_CALLDATA,
+        },
+        opts,
+      );
+
+      expect(result.intent).toBe("Stake POL");
+
+      assert(result.fields);
+      expect(result.fields).toHaveLength(2);
+
+      // Field 0: Stake amount — unit format, 100e18 with decimals=18 → "100POL"
+      const amountField = result.fields[0];
+      assert(!isFieldGroup(amountField));
+      expect(amountField.label).toBe("Stake amount");
+      expect(amountField.value).toBe("100POL");
+      expect(amountField.fieldType).toBe("uint");
+      expect(amountField.format).toBe("unit");
+      expect(amountField.tokenAddress).toBeUndefined();
+      expect(amountField.rawAddress).toBeUndefined();
+      expect(amountField.embeddedCalldata).toBeUndefined();
+      expect(amountField.warning).toBeUndefined();
+
+      // Field 1: Min shares — raw format
+      const minSharesField = result.fields[1];
+      assert(!isFieldGroup(minSharesField));
+      expect(minSharesField.label).toBe("Min shares");
+      expect(minSharesField.value).toBe("12345");
+      expect(minSharesField.fieldType).toBe("uint");
+      expect(minSharesField.format).toBe("raw");
+      expect(minSharesField.tokenAddress).toBeUndefined();
+      expect(minSharesField.rawAddress).toBeUndefined();
+      expect(minSharesField.embeddedCalldata).toBeUndefined();
+      expect(minSharesField.warning).toBeUndefined();
+
+      // Metadata
+      assert(result.metadata);
+      expect(result.metadata.owner).toBe("Yield.xyz");
+      expect(result.metadata.contractName).toBe("YieldxyzPolValidator");
+      expect(result.metadata.info).toEqual({ url: "https://yield.xyz/" });
+
+      expect(result.interpolatedIntent).toBeUndefined();
+      expect(result.rawCalldataFallback).toBeUndefined();
+      expect(result.warnings).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- The Yield.xyz POL Validator descriptor in the official registry uses `$.metadata.constants.stakingTokenTicker` as `params.base` for its unit fields. `formatUnit` was emitting the raw path string verbatim instead of resolving it.
- `formatUnit` now takes `metadata` and resolves `$.metadata.*` base references via `resolveMetadataValue`; literals continue to pass through unchanged. Non-resolving paths fall back to an empty base.
- New registry test case under `test/registry-cases/yieldxyz/` covering `buyVoucherPOL` (descriptor copied verbatim from the registry).
- Updated `formatUnit` unit tests in `test/formatters.spec.ts` (pass `metadata`, add coverage for the metadata-path base and the empty-fallback case).