### PR TITLE
Add registry test case for Lido claimWithdrawals

### DIFF
--- a/test/registry-cases/lido/calldata-WithdrawalQueueERC721.json
+++ b/test/registry-cases/lido/calldata-WithdrawalQueueERC721.json
@@ -1,0 +1,270 @@
+{
+  "$schema": "../../specs/erc7730-v2.schema.json",
+  "context": {
+    "$id": "WithdrawalQueueERC721",
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0x889edC2eDab5f40e902b864aD4d7AdE8E412F9B1"
+        }
+      ]
+    }
+  },
+  "metadata": {
+    "owner": "Lido DAO",
+    "info": { "url": "https://lido.fi" },
+    "constants": {
+      "stETHaddress": "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84",
+      "wstETHaddress": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0"
+    },
+    "contractName": "WithdrawalQueueERC721"
+  },
+  "display": {
+    "formats": {
+      "requestWithdrawals(uint256[] _amounts, address _owner)": {
+        "intent": "Request Withdrawal",
+        "fields": [
+          {
+            "label": "Amount to withdraw",
+            "format": "tokenAmount",
+            "path": "#._amounts.[]",
+            "params": { "token": "$.metadata.constants.stETHaddress" },
+            "visible": "always"
+          },
+          {
+            "label": "Beneficiary",
+            "format": "addressName",
+            "params": {
+              "types": ["eoa", "wallet"],
+              "sources": ["local", "ens"]
+            },
+            "path": "#._owner",
+            "visible": "always"
+          }
+        ]
+      },
+      "requestWithdrawalsWithPermit(uint256[] _amounts, address _owner, (uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) _permit)": {
+        "intent": "Request Withdrawal",
+        "fields": [
+          {
+            "label": "Amount to withdraw",
+            "format": "tokenAmount",
+            "path": "#._amounts.[]",
+            "params": { "token": "$.metadata.constants.stETHaddress" },
+            "visible": "always"
+          },
+          {
+            "label": "Beneficiary",
+            "format": "addressName",
+            "params": {
+              "types": ["eoa", "wallet"],
+              "sources": ["local", "ens"]
+            },
+            "path": "#._owner",
+            "visible": "always"
+          },
+          {
+            "label": "Permit Value",
+            "path": "#._permit.value",
+            "visible": "never"
+          },
+          {
+            "label": "Permit Deadline",
+            "path": "#._permit.deadline",
+            "visible": "never"
+          },
+          { "label": "Permit V", "path": "#._permit.v", "visible": "never" },
+          { "label": "Permit R", "path": "#._permit.r", "visible": "never" },
+          { "label": "Permit S", "path": "#._permit.s", "visible": "never" }
+        ]
+      },
+      "requestWithdrawalsWstETH(uint256[] _amounts, address _owner)": {
+        "intent": "Request withdrawal",
+        "fields": [
+          {
+            "label": "Amount to withdraw",
+            "format": "tokenAmount",
+            "path": "#._amounts.[]",
+            "params": { "token": "$.metadata.constants.wstETHaddress" },
+            "visible": "always"
+          },
+          {
+            "label": "Beneficiary",
+            "format": "addressName",
+            "params": {
+              "types": ["eoa", "wallet"],
+              "sources": ["local", "ens"],
+              "senderAddress": ["0x0000000000000000000000000000000000000000"]
+            },
+            "path": "#._owner",
+            "visible": "always"
+          }
+        ]
+      },
+      "requestWithdrawalsWstETHWithPermit(uint256[] _amounts, address _owner, (uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) _permit)": {
+        "intent": "Request withdrawal",
+        "fields": [
+          {
+            "label": "Amount to withdraw",
+            "format": "tokenAmount",
+            "path": "#._amounts.[]",
+            "params": { "token": "$.metadata.constants.wstETHaddress" },
+            "visible": "always"
+          },
+          {
+            "label": "Beneficiary",
+            "format": "addressName",
+            "params": {
+              "types": ["eoa", "wallet"],
+              "sources": ["local", "ens"]
+            },
+            "path": "#._owner",
+            "visible": "always"
+          },
+          { "label": "Permit", "path": "#._permit", "visible": "never" }
+        ]
+      },
+      "claimWithdrawal(uint256 _requestId)": {
+        "intent": "claim withdrawal",
+        "fields": [
+          {
+            "label": "Request ID",
+            "format": "raw",
+            "path": "#._requestId",
+            "visible": "always"
+          }
+        ]
+      },
+      "claimWithdrawals(uint256[] _requestIds, uint256[] _hints)": {
+        "intent": "claim withdrawals",
+        "fields": [
+          {
+            "label": "Request ID",
+            "format": "raw",
+            "path": "#._requestIds.[]",
+            "visible": "always"
+          },
+          { "label": "Hints", "path": "#._hints.[]", "visible": "never" }
+        ]
+      },
+      "claimWithdrawalsTo(uint256[] _requestIds, uint256[] _hints, address _recipient)": {
+        "intent": "claim withdrawals",
+        "fields": [
+          {
+            "label": "Request IDs",
+            "format": "raw",
+            "path": "#._requestIds.[]",
+            "visible": "always"
+          },
+          {
+            "label": "ETH recipient",
+            "format": "addressName",
+            "params": {
+              "types": ["eoa", "wallet"],
+              "sources": ["local", "ens"]
+            },
+            "path": "#._recipient",
+            "visible": "always"
+          },
+          { "label": "Hints", "path": "#._hints.[]", "visible": "never" }
+        ]
+      },
+      "approve(address _to, uint256 _requestId)": {
+        "intent": "Approve unstETH NFT",
+        "fields": [
+          {
+            "label": "Operator address",
+            "format": "addressName",
+            "params": { "types": ["contract"], "sources": ["local"] },
+            "path": "#._to"
+          },
+          { "label": "Request ID", "format": "raw", "path": "#._requestId" }
+        ]
+      },
+      "safeTransferFrom(address _from, address _to, uint256 _requestId)": {
+        "intent": "Transfer unstETH NFT",
+        "fields": [
+          {
+            "label": "From",
+            "format": "addressName",
+            "params": {
+              "types": ["eoa", "wallet"],
+              "sources": ["local", "ens"]
+            },
+            "path": "#._from",
+            "visible": "always"
+          },
+          {
+            "label": "To",
+            "format": "addressName",
+            "params": {
+              "types": ["eoa", "wallet"],
+              "sources": ["local", "ens"]
+            },
+            "path": "#._to",
+            "visible": "always"
+          },
+          {
+            "label": "Request ID",
+            "format": "raw",
+            "path": "#._requestId",
+            "visible": "always"
+          }
+        ]
+      },
+      "transferFrom(address _from, address _to, uint256 _requestId)": {
+        "intent": "Transfer unstETH NFT",
+        "fields": [
+          {
+            "label": "From",
+            "format": "addressName",
+            "params": {
+              "types": ["eoa", "wallet"],
+              "sources": ["local", "ens"]
+            },
+            "path": "#._from",
+            "visible": "always"
+          },
+          {
+            "label": "To",
+            "format": "addressName",
+            "params": {
+              "types": ["eoa", "wallet"],
+              "sources": ["local", "ens"]
+            },
+            "path": "#._to",
+            "visible": "always"
+          },
+          {
+            "label": "Request ID",
+            "format": "raw",
+            "path": "#._requestId",
+            "visible": "always"
+          }
+        ]
+      },
+      "setApprovalForAll(address _operator, bool _approved)": {
+        "intent": "Approve unstETH NFTs",
+        "fields": [
+          {
+            "label": "Operator",
+            "format": "addressName",
+            "params": {
+              "types": ["eoa", "wallet"],
+              "sources": ["local", "ens"]
+            },
+            "path": "#._operator",
+            "visible": "always"
+          },
+          {
+            "label": "Approved",
+            "format": "raw",
+            "path": "#._approved",
+            "visible": "always"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/registry-cases/lido/lido.spec.ts
+++ b/test/registry-cases/lido/lido.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * Tests for Lido WithdrawalQueueERC721 descriptor:
+ * - claimWithdrawals: uint256[] array iteration with a visible-never sibling array
+ */
+
+import { describe, it, expect, assert } from "vitest";
+import { format, isFieldGroup } from "../../../src/index.js";
+import type { DisplayModel } from "../../../src/types.js";
+import { buildEmbeddedResolverOpts } from "../../utils.js";
+
+describe("Lido WithdrawalQueueERC721", () => {
+  const CHAIN_ID = 1;
+  const CONTRACT = "0x889edC2eDab5f40e902b864aD4d7AdE8E412F9B1";
+
+  function buildOpts() {
+    return buildEmbeddedResolverOpts(__dirname, {
+      calldataDescriptorFiles: [
+        {
+          chainId: CHAIN_ID,
+          address: CONTRACT,
+          file: "calldata-WithdrawalQueueERC721.json",
+        },
+      ],
+    });
+  }
+
+  // =========================================================================
+  // claimWithdrawals
+  // =========================================================================
+  describe("claimWithdrawals", () => {
+    // Calldata extracted from mainnet tx
+    //   0x79a234f238f16b22ff70a2023fbbba8cf4982f46c795eeee6ffd0232d942fa99
+    //   selector:    0xe3afe0a3 = claimWithdrawals(uint256[],uint256[])
+    //   _requestIds: [93761]               (0x16e41)
+    //   _hints:      [844]      (visible: never; 0x34c)
+    const CLAIM_WITHDRAWALS_CALLDATA =
+      "0xe3afe0a3" +
+      "0000000000000000000000000000000000000000000000000000000000000040" + // offset to _requestIds
+      "0000000000000000000000000000000000000000000000000000000000000080" + // offset to _hints
+      "0000000000000000000000000000000000000000000000000000000000000001" + // _requestIds.length = 1
+      "0000000000000000000000000000000000000000000000000000000000016e41" + // _requestIds[0] = 93761
+      "0000000000000000000000000000000000000000000000000000000000000001" + // _hints.length = 1
+      "000000000000000000000000000000000000000000000000000000000000034c"; // _hints[0] = 844
+
+    it("formats claimWithdrawals iterating over visible request IDs only", async () => {
+      const opts = buildOpts();
+
+      const result: DisplayModel = await format(
+        {
+          chainId: CHAIN_ID,
+          to: CONTRACT,
+          data: CLAIM_WITHDRAWALS_CALLDATA,
+        },
+        opts,
+      );
+
+      expect(result.intent).toBe("claim withdrawals");
+
+      assert(result.fields);
+      // Only _requestIds is visible → 1 DisplayFieldGroup
+      expect(result.fields).toHaveLength(1);
+
+      const requestIdsGroup = result.fields[0];
+      assert(isFieldGroup(requestIdsGroup));
+      expect(requestIdsGroup.label).toBeUndefined();
+      expect(requestIdsGroup.warning).toBeUndefined();
+      expect(requestIdsGroup.fields).toHaveLength(1);
+
+      const requestIdField = requestIdsGroup.fields[0];
+      assert(!isFieldGroup(requestIdField));
+      expect(requestIdField.label).toBe("Request ID");
+      expect(requestIdField.value).toBe("93761");
+      expect(requestIdField.fieldType).toBe("uint");
+      expect(requestIdField.format).toBe("raw");
+      expect(requestIdField.tokenAddress).toBeUndefined();
+      expect(requestIdField.rawAddress).toBeUndefined();
+      expect(requestIdField.embeddedCalldata).toBeUndefined();
+      expect(requestIdField.warning).toBeUndefined();
+
+      assert(result.metadata);
+      expect(result.metadata.owner).toBe("Lido DAO");
+      expect(result.metadata.contractName).toBe("WithdrawalQueueERC721");
+      expect(result.metadata.info).toEqual({ url: "https://lido.fi" });
+
+      expect(result.interpolatedIntent).toBeUndefined();
+      expect(result.rawCalldataFallback).toBeUndefined();
+      expect(result.warnings).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a registry test case for the Lido WithdrawalQueueERC721 descriptor covering `claimWithdrawals(uint256[] _requestIds, uint256[] _hints)`.
- Uses real mainnet calldata from tx [`0x79a234f238…fa99`](https://etherscan.io/tx/0x79a234f238f16b22ff70a2023fbbba8cf4982f46c795eeee6ffd0232d942fa99).
- Verifies `_requestIds.[]` array iteration produces a `DisplayFieldGroup` with the expected raw uint field, and that the `visible: never` `_hints.[]` array is omitted from the output. No source changes needed — the existing implementation handles this descriptor correctly.