### PR TITLE
fix(resolver): pass with { type: "json" } on dynamic JSON imports

### DIFF
--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -57,7 +57,9 @@ async function createResolver(
       return {
         index: options.index,
         fetchDescriptor: async (path) => {
-          const mod = await import(`${options.descriptorDirectory}/${path}`);
+          const mod = await import(`${options.descriptorDirectory}/${path}`, {
+            with: { type: "json" },
+          });
           return (mod.default ?? mod) as Descriptor;
         },
       };

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -8,4 +8,10 @@ export default defineConfig({
   sourcemap: true,
   target: "es2022",
   platform: "neutral",
+  esbuildOptions(options) {
+    options.supported = {
+      ...options.supported,
+      "import-attributes": true,
+    };
+  },
 });


### PR DESCRIPTION
## Summary

- Without the `with { type: "json" }` attribute, Node 22+ ESM consumers using the `embedded` resolver hit `ERR_IMPORT_ATTRIBUTE_MISSING` on every descriptor load and have to wrap each descriptor as a `.mjs` module to work around it.
- One-line fix in [src/resolver.ts](src/resolver.ts) adds the attribute to the dynamic `import()` in the `case "embedded"` branch. CJS, React Native, and browser bundlers drop the attribute and use their native JSON loaders, so those paths are unaffected.
- esbuild strips import attributes when targeting `es2022`, so the source change alone is invisible in the published build. The `tsup.config.ts` change sets `supported["import-attributes"] = true` so the attribute survives the build.
- Lets downstream consumers (e.g. `clear-signing-test-runner`) drop their `.mjs` staging workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)