### PR TITLE
Resolve $.metadata.* references in field value

### DIFF
--- a/src/descriptor.ts
+++ b/src/descriptor.ts
@@ -309,12 +309,24 @@ export function mergeDefinitions(
 
 /**
  * Resolve a field's value using its `value` (literal) or `path` property.
+ *
+ * `value` strings that begin with `$.metadata.` are resolved via the path
+ * resolver so that descriptors can reuse constants declared under
+ * `metadata.constants` (or other metadata fields) as field values.
  */
 export function resolveFieldValue(
   field: DescriptorFieldFormat,
   resolvePath: ResolvePath,
 ): ArgumentValue | BytesSliceValue | undefined {
-  if (field.value !== undefined) return toArgumentValue(field.value);
+  if (field.value !== undefined) {
+    if (
+      typeof field.value === "string" &&
+      field.value.startsWith("$.metadata.")
+    ) {
+      return resolvePath(field.value);
+    }
+    return toArgumentValue(field.value);
+  }
   if (field.path !== undefined) return resolvePath(field.path);
   return undefined;
 }

--- a/test/registry-cases/yieldxyz/calldata-yieldxyz-usde-vault.json
+++ b/test/registry-cases/yieldxyz/calldata-yieldxyz-usde-vault.json
@@ -1,0 +1,126 @@
+{
+  "$schema": "../../specs/erc7730-v2.schema.json",
+  "metadata": {
+    "owner": "Yield.xyz",
+    "info": { "url": "https://yield.xyz/" },
+    "constants": {
+      "underlyingToken": "0x4c9EDD5852cd905f086C759E8383e09bff1E68B3",
+      "underlyingTicker": "USDe",
+      "vaultTicker": "stk-USDe"
+    }
+  },
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0x2D152fB171353E70e45322D32bC748F8a61d9971"
+        }
+      ]
+    }
+  },
+  "display": {
+    "formats": {
+      "deposit(uint256 _underlying, address receiver)": {
+        "intent": "Deposit",
+        "fields": [
+          {
+            "path": "_underlying",
+            "label": "Deposit asset",
+            "format": "tokenAmount",
+            "params": { "token": "$.metadata.constants.underlyingToken" },
+            "visible": "always"
+          },
+          {
+            "label": "Share ticker",
+            "format": "raw",
+            "value": "$.metadata.constants.vaultTicker"
+          },
+          {
+            "path": "receiver",
+            "label": "Send shares to",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] },
+            "visible": "always"
+          }
+        ]
+      },
+      "mint(uint256 shares, address receiver)": {
+        "intent": "Mint",
+        "fields": [
+          {
+            "label": "Deposit asset",
+            "format": "raw",
+            "value": "$.metadata.constants.underlyingTicker"
+          },
+          {
+            "path": "shares",
+            "label": "Minted shares",
+            "format": "tokenAmount",
+            "params": { "tokenPath": "@.to" },
+            "visible": "always"
+          },
+          {
+            "path": "receiver",
+            "label": "Mint shares to",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] },
+            "visible": "always"
+          }
+        ]
+      },
+      "withdraw(uint256 _underlying, address receiver, address owner)": {
+        "intent": "Withdraw",
+        "fields": [
+          {
+            "path": "_underlying",
+            "label": "Withdraw exactly",
+            "format": "tokenAmount",
+            "params": { "token": "$.metadata.constants.underlyingToken" },
+            "visible": "always"
+          },
+          {
+            "path": "receiver",
+            "label": "To",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] },
+            "visible": "always"
+          },
+          {
+            "path": "owner",
+            "label": "Owner",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] },
+            "visible": "always"
+          }
+        ]
+      },
+      "redeem(uint256 shares, address receiver, address owner)": {
+        "intent": "Redeem",
+        "fields": [
+          {
+            "path": "shares",
+            "label": "Shares to redeem",
+            "format": "tokenAmount",
+            "params": { "tokenPath": "@.to" },
+            "visible": "always"
+          },
+          {
+            "path": "receiver",
+            "label": "To",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] },
+            "visible": "always"
+          },
+          {
+            "path": "owner",
+            "label": "Owner",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] },
+            "visible": "always"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/registry-cases/yieldxyz/yieldxyz.spec.ts
+++ b/test/registry-cases/yieldxyz/yieldxyz.spec.ts
@@ -1,12 +1,20 @@
 /**
- * Tests for Yield.xyz POL Validator descriptor:
- * - buyVoucherPOL: unit format with $.metadata.constants base interpolation
+ * Tests for Yield.xyz descriptors:
+ * - POL Validator buyVoucherPOL: unit format with $.metadata.constants base interpolation
+ * - USDe Vault deposit: tokenAmount with $.metadata.constants.* token address,
+ *   raw field whose `value` is a $.metadata.constants.* reference,
+ *   and addressName for the share recipient
  */
 
 import { describe, it, expect, assert } from "vitest";
 import { format, isFieldGroup } from "../../../src/index.js";
-import type { DisplayModel } from "../../../src/types.js";
-import { bytesToHex, selectorForSignature } from "../../../src/utils.js";
+import type { DisplayModel, ExternalDataProvider } from "../../../src/types.js";
+import {
+  bytesToHex,
+  hexToBytes,
+  selectorForSignature,
+  toChecksumAddress,
+} from "../../../src/utils.js";
 import { buildEmbeddedResolverOpts } from "../../utils.js";
 
 describe("Yield.xyz POL Validator", () => {
@@ -86,6 +94,134 @@ describe("Yield.xyz POL Validator", () => {
       assert(result.metadata);
       expect(result.metadata.owner).toBe("Yield.xyz");
       expect(result.metadata.contractName).toBe("YieldxyzPolValidator");
+      expect(result.metadata.info).toEqual({ url: "https://yield.xyz/" });
+
+      expect(result.interpolatedIntent).toBeUndefined();
+      expect(result.rawCalldataFallback).toBeUndefined();
+      expect(result.warnings).toBeUndefined();
+    });
+  });
+});
+
+describe("Yield.xyz USDe Vault", () => {
+  const CHAIN_ID = 1;
+  const CONTRACT = "0x2D152fB171353E70e45322D32bC748F8a61d9971";
+  const USDE_TOKEN = "0x4c9edd5852cd905f086c759e8383e09bff1e68b3";
+  const RECEIVER = "0x2fec9b58d089447d3e5e50578b9f71321713a470";
+
+  function buildOpts(externalDataProvider?: ExternalDataProvider) {
+    return buildEmbeddedResolverOpts(
+      __dirname,
+      {
+        calldataDescriptorFiles: [
+          {
+            chainId: CHAIN_ID,
+            address: CONTRACT,
+            file: "calldata-yieldxyz-usde-vault.json",
+          },
+        ],
+      },
+      externalDataProvider,
+    );
+  }
+
+  // =========================================================================
+  // deposit
+  // =========================================================================
+  describe("deposit", () => {
+    // deposit(uint256 _underlying, address receiver)
+    //   _underlying = 100 * 10^18  (100 USDe)
+    //   receiver    = 0x2fec…a470
+    const SELECTOR = bytesToHex(
+      selectorForSignature("deposit(uint256,address)"),
+    );
+
+    const DEPOSIT_CALLDATA =
+      SELECTOR +
+      "0000000000000000000000000000000000000000000000056bc75e2d63100000" + // _underlying = 100e18
+      "0000000000000000000000002fec9b58d089447d3e5e50578b9f71321713a470"; // receiver
+
+    const resolveToken: ExternalDataProvider["resolveToken"] = async (
+      chainId,
+      tokenAddress,
+    ) => {
+      if (chainId === CHAIN_ID && tokenAddress === USDE_TOKEN) {
+        return { name: "USDe", symbol: "USDe", decimals: 18 };
+      }
+      return null;
+    };
+
+    const resolveLocalName: ExternalDataProvider["resolveLocalName"] = async (
+      address,
+    ) => {
+      if (address === RECEIVER) {
+        return { name: "alice.eth", typeMatch: true };
+      }
+      return null;
+    };
+
+    it("renders deposit asset, share ticker constant, and recipient name", async () => {
+      const opts = buildOpts({ resolveToken, resolveLocalName });
+
+      const result: DisplayModel = await format(
+        {
+          chainId: CHAIN_ID,
+          to: CONTRACT,
+          data: DEPOSIT_CALLDATA,
+        },
+        opts,
+      );
+
+      expect(result.intent).toBe("Deposit");
+
+      assert(result.fields);
+      expect(result.fields).toHaveLength(3);
+
+      // Field 0: Deposit asset — tokenAmount, 100e18 with USDe decimals=18 → "100 USDe"
+      const depositField = result.fields[0];
+      assert(!isFieldGroup(depositField));
+      expect(depositField.label).toBe("Deposit asset");
+      expect(depositField.value).toBe("100 USDe");
+      expect(depositField.fieldType).toBe("uint");
+      expect(depositField.format).toBe("tokenAmount");
+      expect(depositField.tokenAddress).toBe(
+        toChecksumAddress(hexToBytes(USDE_TOKEN)),
+      );
+      expect(depositField.rawAddress).toBeUndefined();
+      expect(depositField.embeddedCalldata).toBeUndefined();
+      expect(depositField.warning).toBeUndefined();
+
+      // Field 1: Share ticker — raw format with `value` referencing
+      // $.metadata.constants.vaultTicker → "stk-USDe"
+      const tickerField = result.fields[1];
+      assert(!isFieldGroup(tickerField));
+      expect(tickerField.label).toBe("Share ticker");
+      expect(tickerField.value).toBe("stk-USDe");
+      expect(tickerField.fieldType).toBe("string");
+      expect(tickerField.format).toBe("raw");
+      expect(tickerField.tokenAddress).toBeUndefined();
+      expect(tickerField.rawAddress).toBeUndefined();
+      expect(tickerField.embeddedCalldata).toBeUndefined();
+      expect(tickerField.warning).toBeUndefined();
+
+      // Field 2: Send shares to — addressName, receiver → alice.eth
+      const receiverField = result.fields[2];
+      assert(!isFieldGroup(receiverField));
+      expect(receiverField.label).toBe("Send shares to");
+      expect(receiverField.value).toBe("alice.eth");
+      expect(receiverField.fieldType).toBe("address");
+      expect(receiverField.format).toBe("addressName");
+      expect(receiverField.rawAddress).toBe(
+        toChecksumAddress(hexToBytes(RECEIVER)),
+      );
+      expect(receiverField.tokenAddress).toBeUndefined();
+      expect(receiverField.embeddedCalldata).toBeUndefined();
+      expect(receiverField.warning).toBeUndefined();
+
+      // Metadata
+      assert(result.metadata);
+      expect(result.metadata.owner).toBe("Yield.xyz");
+      expect(result.metadata.contractName).toBeUndefined();
       expect(result.metadata.info).toEqual({ url: "https://yield.xyz/" });
 
       expect(result.interpolatedIntent).toBeUndefined();


### PR DESCRIPTION
## Summary
- Add registry test case for the Yield.xyz USDe Vault `deposit(uint256 _underlying, address receiver)` covering `tokenAmount` with a `$.metadata.constants.*` token address, an `addressName` receiver, and a raw `Share ticker` field whose `value` references `$.metadata.constants.vaultTicker`.
- Fix `resolveFieldValue` to resolve `$.metadata.*` references in a field's `value` so the raw ticker field renders the constant instead of the literal pointer string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)