### PR TITLE
Render uint/int values as addresses for address-bearing formats

### DIFF
--- a/src/descriptor.ts
+++ b/src/descriptor.ts
@@ -193,6 +193,28 @@ export function bytesToAddressArgumentValue(
 }
 
 /**
+ * Coerce a resolved path value to an address ArgumentValue.
+ *
+ * Accepts `address` directly, takes the low 20 bytes of a `bytes`/`bytes-slice`
+ * value, and accepts `uint`/`int` whose 32-byte big-endian encoding carries an
+ * address in the low 20 bytes. The latter supports descriptors that declare
+ * addresses as `uint256` in the ABI (1inch's `Address` user-defined type).
+ */
+export function resolvedToAddress(
+  value: ArgumentValue | BytesSliceValue | undefined,
+): { type: "address"; bytes: Uint8Array } | undefined {
+  if (!value) return undefined;
+  if (value.type === "address") return value;
+  if (value.type === "bytes" || value.type === "bytes-slice") {
+    return bytesToAddressArgumentValue(value.bytes);
+  }
+  if (value.type === "uint" || value.type === "int") {
+    return bytesToAddressArgumentValue(bigIntToBytes(value.value));
+  }
+  return undefined;
+}
+
+/**
  * Convert an ArgumentValue to its raw byte representation for byte slicing.
  * - uint/int → 32-byte big-endian (two's complement for negative int)
  * - address → 20 bytes

--- a/src/fields.ts
+++ b/src/fields.ts
@@ -32,6 +32,7 @@ import {
   isFieldGroup,
   mergeDefinitions,
   resolveFieldValue,
+  resolvedToAddress,
   toArgumentValue,
 } from "./descriptor.js";
 import {
@@ -211,11 +212,13 @@ async function processSingleField(
     };
   }
 
-  // Convert bytes-slice to a typed ArgumentValue based on the field format
-  const argValue: ArgumentValue =
-    resolvedValue.type === "bytes-slice"
-      ? bytesSliceToArgumentValue(resolvedValue, merged.format)
-      : resolvedValue;
+  // Convert bytes-slice to a typed ArgumentValue based on the field format,
+  // and coerce uint/int → address when the format expects an address (some
+  // descriptors store addresses in uint256 slots, e.g. 1inch's `Address` type).
+  const argValue: ArgumentValue = coerceResolvedValue(
+    resolvedValue,
+    merged.format,
+  );
 
   const visibility = evaluateVisibility(merged.visible, argValue, merged.label);
   if ("warning" in visibility) return { warnings: [visibility.warning] };
@@ -681,6 +684,31 @@ export function bytesSliceToArgumentValue(
 ): ArgumentValue {
   const fieldType = fieldTypeForFormat(format);
   return bytesSliceToFieldType(slice.bytes, fieldType);
+}
+
+/**
+ * Coerce a resolved value to the ArgumentValue expected by the field format:
+ *   - bytes-slice → re-interpreted as the format's expected primary type
+ *   - uint/int    → coerced to address when the format expects an address
+ *                   (low 20 bytes of the 32-byte big-endian encoding); this
+ *                   supports descriptors that store addresses in uint256 slots
+ *
+ * Falls through to the input value unchanged otherwise.
+ */
+function coerceResolvedValue(
+  value: ArgumentValue | BytesSliceValue,
+  format: DescriptorFieldFormatType,
+): ArgumentValue {
+  if (value.type === "bytes-slice") {
+    return bytesSliceToArgumentValue(value, format);
+  }
+  if (
+    (value.type === "uint" || value.type === "int") &&
+    fieldTypeForFormat(format) === "address"
+  ) {
+    return resolvedToAddress(value) ?? value;
+  }
+  return value;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -17,10 +17,7 @@ import type {
   Warning,
 } from "./types.js";
 import type { ArgumentValue, ResolvePath } from "./descriptor.js";
-import {
-  bytesToAddressArgumentValue,
-  resolveMetadataValue,
-} from "./descriptor.js";
+import { resolveMetadataValue, resolvedToAddress } from "./descriptor.js";
 import {
   bytesToUnsignedBigInt,
   bytesToHex,
@@ -412,11 +409,8 @@ export function resolveTokenAddress(
   }
 
   // Any path ($., @., #., or bare) — resolve via the caller's closure
-  let resolved = resolvePath(token);
-  if (resolved?.type === "bytes-slice") {
-    resolved = bytesToAddressArgumentValue(resolved.bytes);
-  }
-  if (resolved?.type === "address") {
+  const resolved = resolvedToAddress(resolvePath(token));
+  if (resolved) {
     return bytesToHex(resolved.bytes).toLowerCase();
   }
 
@@ -543,11 +537,8 @@ export function resolveCollectionAddress(
   }
 
   // Any path ($., @., #., or bare) — resolve via the caller's closure
-  let resolved = resolvePath(collection);
-  if (resolved?.type === "bytes-slice") {
-    resolved = bytesToAddressArgumentValue(resolved.bytes);
-  }
-  if (resolved?.type === "address") {
+  const resolved = resolvedToAddress(resolvePath(collection));
+  if (resolved) {
     return bytesToHex(resolved.bytes).toLowerCase();
   }
 
@@ -903,11 +894,8 @@ function resolveCallee(
     return spec.toLowerCase();
   }
 
-  let resolved = resolvePath(spec);
-  if (resolved?.type === "bytes-slice") {
-    resolved = bytesToAddressArgumentValue(resolved.bytes);
-  }
-  if (resolved?.type === "address") {
+  const resolved = resolvedToAddress(resolvePath(spec));
+  if (resolved) {
     return bytesToHex(resolved.bytes).toLowerCase();
   }
 
@@ -959,11 +947,8 @@ function resolveSpenderParam(
     return spec.toLowerCase();
   }
 
-  let resolved = resolvePath(spec);
-  if (resolved?.type === "bytes-slice") {
-    resolved = bytesToAddressArgumentValue(resolved.bytes);
-  }
-  if (resolved?.type === "address") {
+  const resolved = resolvedToAddress(resolvePath(spec));
+  if (resolved) {
     return bytesToHex(resolved.bytes).toLowerCase();
   }
 

--- a/test/formatters.spec.ts
+++ b/test/formatters.spec.ts
@@ -335,11 +335,21 @@ describe("resolveTokenAddress", () => {
     );
   });
 
-  it("returns undefined when resolvePath returns non-address", () => {
-    const resolvePath: ResolvePath = () => ({
-      type: "uint",
-      value: 42n,
-    });
+  it("resolves token from a uint resolvePath (1inch Address-as-uint256)", () => {
+    // Address packed in the low 20 bytes of a uint256
+    const usdcAsUint = 0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48n;
+    const resolvePath: ResolvePath = (path) => {
+      if (path === "tokenSlot") return { type: "uint", value: usdcAsUint };
+      return undefined;
+    };
+    const field = { params: { token: "tokenSlot" } };
+    expect(resolveTokenAddress(field, resolvePath)).toBe(
+      "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+    );
+  });
+
+  it("returns undefined when resolvePath returns a non-address-shaped type", () => {
+    const resolvePath: ResolvePath = () => ({ type: "bool", value: true });
     const field = { params: { token: "someField" } };
     expect(resolveTokenAddress(field, resolvePath)).toBeUndefined();
   });

--- a/test/registry-cases/1inch/1inch.spec.ts
+++ b/test/registry-cases/1inch/1inch.spec.ts
@@ -1,13 +1,20 @@
 /**
- * Tests for 1inch AggregationRouterV6 descriptor:
- * - swap: standard token swap with tuple params
- * - clipperSwap: byte slice paths (srcToken.[-20:], goodUntil.[-4:])
+ * Tests for 1inch descriptors:
+ * - AggregationRouterV6.swap: standard token swap with tuple params
+ * - AggregationRouterV6.clipperSwap: byte slice paths (srcToken.[-20:], goodUntil.[-4:])
+ * - NativeOrderFactory.create: tuple with addresses declared as uint256
+ *   (1inch's Address-as-uint256 convention)
  */
 
 import { describe, it, expect, assert } from "vitest";
 import { format, isFieldGroup } from "../../../src/index.js";
 import type { DisplayModel, ExternalDataProvider } from "../../../src/types.js";
-import { toChecksumAddress, hexToBytes } from "../../../src/utils.js";
+import {
+  bytesToHex,
+  hexToBytes,
+  selectorForSignature,
+  toChecksumAddress,
+} from "../../../src/utils.js";
 import { buildEmbeddedResolverOpts } from "../../utils.js";
 
 describe("1inch AggregationRouterV6", () => {
@@ -294,6 +301,172 @@ describe("1inch AggregationRouterV6", () => {
       expect(result.metadata.info).toEqual({
         url: "https://1inch.io/",
         deploymentDate: "2024-02-12T03:44:35Z",
+      });
+
+      expect(result.interpolatedIntent).toBeUndefined();
+      expect(result.rawCalldataFallback).toBeUndefined();
+      expect(result.warnings).toBeUndefined();
+    });
+  });
+});
+
+describe("1inch NativeOrderFactory", () => {
+  const CHAIN_ID = 1;
+  const CONTRACT = "0xe12E0f117d23a5ccc57f8935CD8c4E80cD91FF01";
+  const RECEIVER = "0xd8da6bf26964af9d7eed9e03e53415d37aa96045";
+  const USDC = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
+
+  function buildOpts(externalDataProvider?: ExternalDataProvider) {
+    return buildEmbeddedResolverOpts(
+      __dirname,
+      {
+        calldataDescriptorFiles: [
+          {
+            chainId: CHAIN_ID,
+            address: CONTRACT,
+            file: "calldata-NativeOrderFactory.json",
+          },
+        ],
+      },
+      externalDataProvider,
+    );
+  }
+
+  // =========================================================================
+  // create
+  // =========================================================================
+  describe("create", () => {
+    // create((uint256 salt, uint256 maker, uint256 receiver, uint256 makerAsset,
+    //        uint256 takerAsset, uint256 makingAmount, uint256 takingAmount,
+    //        uint256 makerTraits) makerOrder)
+    //
+    // 1inch stores addresses (receiver, makerAsset, takerAsset) inside uint256
+    // slots — the address lives in the low 20 bytes of the 32-byte word.
+    //
+    // Test order: ETH → USDC native swap order, sending 1 ETH for 3000 USDC,
+    // beneficiary is the receiver (vitalik.eth address).
+    const SELECTOR = bytesToHex(
+      selectorForSignature(
+        "create((uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256))",
+      ),
+    );
+
+    const CREATE_CALLDATA =
+      SELECTOR +
+      "0000000000000000000000000000000000000000000000000000000000012345" + // salt
+      "0000000000000000000000000000000000000000000000000000000000000001" + // maker (hidden)
+      "000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045" + // receiver
+      "0000000000000000000000000000000000000000000000000000000000000000" + // makerAsset (hidden)
+      "000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48" + // takerAsset = USDC
+      "0000000000000000000000000000000000000000000000000000000000000000" + // makingAmount (hidden)
+      "00000000000000000000000000000000000000000000000000000000b2d05e00" + // takingAmount = 3000 USDC
+      "0000000000000000000000000000000000000000000000000000000000000000"; // makerTraits (hidden)
+
+    const TX_VALUE = 1000000000000000000n; // 1 ETH
+
+    const resolveChainInfo: ExternalDataProvider["resolveChainInfo"] = async (
+      chainId,
+    ) => {
+      if (chainId === CHAIN_ID) {
+        return {
+          name: "Ethereum Mainnet",
+          nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
+        };
+      }
+      return null;
+    };
+
+    const resolveToken: ExternalDataProvider["resolveToken"] = async (
+      chainId,
+      tokenAddress,
+    ) => {
+      if (chainId === CHAIN_ID && tokenAddress === USDC) {
+        return { name: "USD Coin", symbol: "USDC", decimals: 6 };
+      }
+      return null;
+    };
+
+    const resolveLocalName: ExternalDataProvider["resolveLocalName"] = async (
+      address,
+    ) => {
+      if (address === RECEIVER) {
+        return { name: "vitalik.eth", typeMatch: true };
+      }
+      return null;
+    };
+
+    it("renders an ETH→USDC limit order with uint256-encoded addresses", async () => {
+      const opts = buildOpts({
+        resolveChainInfo,
+        resolveToken,
+        resolveLocalName,
+      });
+
+      const result: DisplayModel = await format(
+        {
+          chainId: CHAIN_ID,
+          to: CONTRACT,
+          value: TX_VALUE,
+          data: CREATE_CALLDATA,
+        },
+        opts,
+      );
+
+      expect(result.intent).toBe("create order");
+
+      assert(result.fields);
+      // Visible: Amount to Send, Receive amount, Beneficiary
+      // Hidden (visible=never): salt, maker, makerAsset, makingAmount, makerTraits
+      expect(result.fields).toHaveLength(3);
+
+      // Field 0: Amount to Send — `@.value` rendered as native ETH amount
+      const sendField = result.fields[0];
+      assert(!isFieldGroup(sendField));
+      expect(sendField.label).toBe("Amount to Send");
+      expect(sendField.value).toBe("1 ETH");
+      expect(sendField.fieldType).toBe("uint");
+      expect(sendField.format).toBe("amount");
+      expect(sendField.tokenAddress).toBeUndefined();
+      expect(sendField.rawAddress).toBeUndefined();
+      expect(sendField.embeddedCalldata).toBeUndefined();
+      expect(sendField.warning).toBeUndefined();
+
+      // Field 1: Receive amount — tokenAmount whose tokenPath points to a
+      // uint256 slot holding the USDC address in its low 20 bytes
+      const receiveField = result.fields[1];
+      assert(!isFieldGroup(receiveField));
+      expect(receiveField.label).toBe("Receive amount");
+      expect(receiveField.value).toBe("3000 USDC");
+      expect(receiveField.fieldType).toBe("uint");
+      expect(receiveField.format).toBe("tokenAmount");
+      expect(receiveField.tokenAddress).toBe(
+        toChecksumAddress(hexToBytes(USDC)),
+      );
+      expect(receiveField.rawAddress).toBeUndefined();
+      expect(receiveField.embeddedCalldata).toBeUndefined();
+      expect(receiveField.warning).toBeUndefined();
+
+      // Field 2: Beneficiary — addressName on a uint256 field holding an address
+      const beneficiaryField = result.fields[2];
+      assert(!isFieldGroup(beneficiaryField));
+      expect(beneficiaryField.label).toBe("Beneficiary");
+      expect(beneficiaryField.value).toBe("vitalik.eth");
+      expect(beneficiaryField.fieldType).toBe("address");
+      expect(beneficiaryField.format).toBe("addressName");
+      expect(beneficiaryField.rawAddress).toBe(
+        toChecksumAddress(hexToBytes(RECEIVER)),
+      );
+      expect(beneficiaryField.tokenAddress).toBeUndefined();
+      expect(beneficiaryField.embeddedCalldata).toBeUndefined();
+      expect(beneficiaryField.warning).toBeUndefined();
+
+      // Metadata
+      assert(result.metadata);
+      expect(result.metadata.owner).toBe("1inch Network");
+      expect(result.metadata.contractName).toBe("NativeOrderFactory");
+      expect(result.metadata.info).toEqual({
+        url: "https://1inch.io/",
+        deploymentDate: "2025-09-26T02:02:59Z",
       });
 
       expect(result.interpolatedIntent).toBeUndefined();

--- a/test/registry-cases/1inch/calldata-NativeOrderFactory.json
+++ b/test/registry-cases/1inch/calldata-NativeOrderFactory.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "../../specs/erc7730-v2.schema.json",
+  "context": {
+    "$id": "NativeOrderFactory",
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0xe12E0f117d23a5ccc57f8935CD8c4E80cD91FF01"
+        },
+        {
+          "chainId": 10,
+          "address": "0xe12E0f117d23a5ccc57f8935CD8c4E80cD91FF01"
+        },
+        {
+          "chainId": 56,
+          "address": "0xe12E0f117d23a5ccc57f8935CD8c4E80cD91FF01"
+        },
+        {
+          "chainId": 100,
+          "address": "0xe12E0f117d23a5ccc57f8935CD8c4E80cD91FF01"
+        },
+        {
+          "chainId": 137,
+          "address": "0xe12E0f117d23a5ccc57f8935CD8c4E80cD91FF01"
+        },
+        {
+          "chainId": 146,
+          "address": "0xe12E0f117d23a5ccc57f8935CD8c4E80cD91FF01"
+        },
+        {
+          "chainId": 8453,
+          "address": "0xe12E0f117d23a5ccc57f8935CD8c4E80cD91FF01"
+        },
+        {
+          "chainId": 42161,
+          "address": "0xe12E0f117d23a5ccc57f8935CD8c4E80cD91FF01"
+        },
+        {
+          "chainId": 43114,
+          "address": "0xe12E0f117d23a5ccc57f8935CD8c4E80cD91FF01"
+        },
+        {
+          "chainId": 59144,
+          "address": "0xe12E0f117d23a5ccc57f8935CD8c4E80cD91FF01"
+        }
+      ]
+    }
+  },
+  "metadata": {
+    "owner": "1inch Network",
+    "info": {
+      "url": "https://1inch.io/",
+      "deploymentDate": "2025-09-26T02:02:59Z"
+    },
+    "constants": {
+      "addressAsEth": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+      "addressAsNull": "0x0000000000000000000000000000000000000000"
+    },
+    "contractName": "NativeOrderFactory"
+  },
+  "display": {
+    "formats": {
+      "create((uint256 salt, uint256 maker, uint256 receiver, uint256 makerAsset, uint256 takerAsset, uint256 makingAmount, uint256 takingAmount, uint256 makerTraits) makerOrder)": {
+        "$id": "create",
+        "intent": "create order",
+        "fields": [
+          { "label": "Amount to Send", "path": "@.value", "format": "amount" },
+          {
+            "label": "Receive amount",
+            "path": "makerOrder.takingAmount",
+            "format": "tokenAmount",
+            "params": {
+              "tokenPath": "makerOrder.takerAsset",
+              "nativeCurrencyAddress": [
+                "$.metadata.constants.addressAsEth",
+                "$.metadata.constants.addressAsNull"
+              ]
+            },
+            "visible": "always"
+          },
+          {
+            "label": "Beneficiary",
+            "path": "makerOrder.receiver",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] },
+            "visible": "always"
+          },
+          {
+            "label": "Maker Order Salt",
+            "path": "makerOrder.salt",
+            "visible": "never"
+          },
+          {
+            "label": "Maker Order Maker",
+            "path": "makerOrder.maker",
+            "visible": "never"
+          },
+          {
+            "label": "Maker Order Maker Asset",
+            "path": "makerOrder.makerAsset",
+            "visible": "never"
+          },
+          {
+            "label": "Maker Order Making Amount",
+            "path": "makerOrder.makingAmount",
+            "visible": "never"
+          },
+          {
+            "label": "Maker Order Maker Traits",
+            "path": "makerOrder.makerTraits",
+            "visible": "never"
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add registry test case for `1inch NativeOrderFactory.create((...) makerOrder)` covering an ETH→USDC limit order whose tuple stores `receiver` and `takerAsset` as `uint256` slots holding addresses in their low 20 bytes (1inch's `Address` user-defined type).
- Add a shared `resolvedToAddress` coercion helper that accepts `address`, `bytes`, `bytes-slice`, or `uint`/`int` (low 20 bytes of the 32-byte big-endian encoding) and use it in `resolveTokenAddress`, `resolveCollectionAddress`, `resolveCallee`, and `resolveSpenderParam`.
- In `processSingleField`, coerce `uint`/`int` → `address` when the field's format expects an address (e.g. `addressName`), so descriptors that declare address-bearing fields as `uint256` render correctly instead of emitting `ARGUMENT_TYPE_MISMATCH`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)