### PR TITLE
Support struct field groups with relative child paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,10 @@ src/
 - **`fields.ts`** — The field processing pipeline. Primary entry point is `applyFieldFormats()`,
   which iterates format fields, merges definitions, resolves values, and renders each field.
   Handles field groups with array iteration (group-level and child-level patterns, sequential
-  and bundled modes). Delegates individual field rendering to `formatters.ts`.
+  and bundled modes) as well as struct groups (group path points to a static tuple, children
+  resolved relative to it; always emitted as a DisplayFieldGroup, with the group's `label`
+  passed through as-is — may be undefined).
+  Delegates individual field rendering to `formatters.ts`.
   Contains byte slice support: `parseByteSlice`, `applyByteSlice`, `buildSliceResolvePath`
   (wraps a `BaseResolvePath` to handle slice paths transparently), and
   `bytesSliceToArgumentValue` (converts `BytesSliceValue` to `ArgumentValue` using the

--- a/src/fields.ts
+++ b/src/fields.ts
@@ -102,7 +102,9 @@ export async function applyFieldFormats(
     if (isFieldGroup(fieldSpec)) {
       const groupResult = fieldSpec.path?.endsWith(".[]")
         ? await processGroupArrayPath(fieldSpec, ctx)
-        : await processChildArrayPaths(fieldSpec, ctx);
+        : groupHasArrayChildren(fieldSpec)
+          ? await processChildArrayPaths(fieldSpec, ctx)
+          : await processStructGroup(fieldSpec, ctx);
       if ("warnings" in groupResult) return groupResult;
       fields.push(groupResult.group);
     } else if (fieldSpec.path?.endsWith(".[]")) {
@@ -329,7 +331,7 @@ async function processChildArrayPaths(
   const paramMismatch = checkParamArrayLengths(childFields, arrayLengths, ctx);
   if (paramMismatch) return { warnings: [paramMismatch] };
 
-  if (arrayLengths.length === 0 || arrayLengths.every((a) => a.length === 0)) {
+  if (arrayLengths.every((a) => a.length === 0)) {
     return {
       group: emptyArrayGroup(group.label, "All arrays in group are empty"),
     };
@@ -398,6 +400,46 @@ async function processChildArrayPaths(
 
   joinArrayValues(arrayLengths, ctx.renderedValues);
   return { group: { label: group.label, fields: allFields } };
+}
+
+/**
+ * Pattern 3: Group path points to a static tuple (no .[] anywhere).
+ * Children are resolved relative to the tuple path — e.g. group
+ * `path: "#.swapData"` with child `path: "fromAmount"` resolves to
+ * `swapData.fromAmount`. Always returns a DisplayFieldGroup (label may be
+ * undefined); the rendering UI decides how to display unlabeled groups.
+ */
+async function processStructGroup(
+  group: DescriptorFieldGroup,
+  ctx: FieldContext,
+): Promise<{ group: DisplayFieldGroup } | { warnings: Warning[] }> {
+  const prefix = parseGroupBasePath(group.path).replace(/^#\./, "");
+
+  const scopedCtx: FieldContext = prefix
+    ? {
+        ...ctx,
+        resolvePath: (path: string) => {
+          if (path.startsWith("@.") || path.startsWith("$.")) {
+            return ctx.resolvePath(path);
+          }
+          const key = path.startsWith("#.") ? path.slice(2) : path;
+          return ctx.resolvePath(`${prefix}.${key}`);
+        },
+      }
+    : ctx;
+
+  const result = await processFlatFields(group.fields ?? [], scopedCtx);
+  if ("warnings" in result) return result;
+
+  return { group: { label: group.label, fields: result.fields } };
+}
+
+/** True iff any direct child of the group has an `.[]` array iterator in its path. */
+function groupHasArrayChildren(group: DescriptorFieldGroup): boolean {
+  for (const child of group.fields ?? []) {
+    if (!isFieldGroup(child) && child.path?.includes(".[]")) return true;
+  }
+  return false;
 }
 
 /**

--- a/test/registry-cases/paraswap/paraswap.spec.ts
+++ b/test/registry-cases/paraswap/paraswap.spec.ts
@@ -2,6 +2,7 @@
  * Tests for Paraswap AugustusSwapper v6.2 descriptor:
  * - swapOnAugustusRFQTryBatchFill: tuple array decoding + array index access
  * - swapExactAmountOutOnBalancerV2: dynamic bytes + byte slices
+ * - swapExactAmountInOnCurveV1: static tuple with relative tokenPath
  */
 
 import { describe, it, expect, assert } from "vitest";
@@ -406,6 +407,120 @@ describe("Paraswap AugustusSwapper v6.2", () => {
       expect(beneficiaryField.format).toBe("addressName");
       expect(beneficiaryField.rawAddress).toBe(
         toChecksumAddress(hexToBytes(FROM)),
+      );
+      expect(beneficiaryField.tokenAddress).toBeUndefined();
+      expect(beneficiaryField.embeddedCalldata).toBeUndefined();
+      expect(beneficiaryField.warning).toBeUndefined();
+
+      // Metadata
+      assert(result.metadata);
+      expect(result.metadata.owner).toBe("Velora");
+      expect(result.metadata.contractName).toBe("AugustusSwapperV6.2");
+      expect(result.metadata.info).toEqual({
+        url: "https://www.velora.xyz/",
+      });
+
+      expect(result.interpolatedIntent).toBeUndefined();
+      expect(result.rawCalldataFallback).toBeUndefined();
+      expect(result.warnings).toBeUndefined();
+    });
+  });
+
+  // =========================================================================
+  // swapExactAmountInOnCurveV1
+  // =========================================================================
+  describe("swapExactAmountInOnCurveV1", () => {
+    // ABI-encoded calldata:
+    //   curveV1Data is a static tuple (9 static fields = 288 bytes inline)
+    //   curveV1Data.srcToken = USDC
+    //   curveV1Data.destToken = DAI
+    //   curveV1Data.fromAmount = 1,000,000 (1 USDC)
+    //   curveV1Data.toAmount = 950,000,000,000,000,000 (0.95 DAI)
+    //   curveV1Data.beneficiary = BENEFICIARY
+    //   partnerAndFee = 0
+    //   permit = empty bytes
+    // Head layout (after selector):
+    //   bytes 0-287:   curveV1Data tuple (9 words)
+    //   bytes 288-319: partnerAndFee
+    //   bytes 320-351: permit offset = 0x160 (352)
+    //   bytes 352+:    permit length (0) + content
+    const CURVE_V1_CALLDATA =
+      "0x1a01c532" +
+      // curveV1Data tuple (9 words):
+      "0000000000000000000000000000000000000000000000000000000000000000" + // curveData
+      "0000000000000000000000000000000000000000000000000000000000000000" + // curveAssets
+      "000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48" + // srcToken (USDC)
+      "0000000000000000000000006b175474e89094c44da98b954eedeac495271d0f" + // destToken (DAI)
+      "00000000000000000000000000000000000000000000000000000000000f4240" + // fromAmount = 1e6
+      "0000000000000000000000000000000000000000000000000d2f13f7789f0000" + // toAmount = 0.95e18
+      "0000000000000000000000000000000000000000000000000000000000000000" + // quotedAmount
+      "0000000000000000000000000000000000000000000000000000000000000000" + // metadata
+      "000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045" + // beneficiary
+      // partnerAndFee:
+      "0000000000000000000000000000000000000000000000000000000000000000" +
+      // permit offset (0x160 = 352):
+      "0000000000000000000000000000000000000000000000000000000000000160" +
+      // --- permit (length=0) ---
+      "0000000000000000000000000000000000000000000000000000000000000000";
+
+    it("formats CurveV1 swap with relative tokenPath inside a static tuple", async () => {
+      const opts = buildOpts({ resolveToken, resolveLocalName });
+
+      const result = await format(
+        {
+          chainId: CHAIN_ID,
+          to: CONTRACT,
+          from: FROM,
+          data: CURVE_V1_CALLDATA,
+        },
+        opts,
+      );
+
+      expect(result.intent).toBe("Swap");
+
+      assert(result.fields);
+      // 1 unlabeled DisplayFieldGroup wrapping the curveV1Data struct fields
+      expect(result.fields).toHaveLength(1);
+
+      const curveGroup = result.fields[0];
+      assert(isFieldGroup(curveGroup));
+      expect(curveGroup.label).toBeUndefined();
+      expect(curveGroup.warning).toBeUndefined();
+      // 3 visible children: fromAmount, toAmount, beneficiary
+      expect(curveGroup.fields).toHaveLength(3);
+
+      // Child 0: Amount to Send — tokenPath = srcToken (USDC)
+      const sendField = curveGroup.fields[0];
+      expect(sendField.label).toBe("Amount to Send");
+      expect(sendField.value).toBe("1 USDC");
+      expect(sendField.fieldType).toBe("uint");
+      expect(sendField.format).toBe("tokenAmount");
+      expect(sendField.tokenAddress).toBe(toChecksumAddress(hexToBytes(USDC)));
+      expect(sendField.embeddedCalldata).toBeUndefined();
+      expect(sendField.rawAddress).toBeUndefined();
+      expect(sendField.warning).toBeUndefined();
+
+      // Child 1: Minimum to Receive — tokenPath = destToken (DAI)
+      const receiveField = curveGroup.fields[1];
+      expect(receiveField.label).toBe("Minimum to Receive");
+      expect(receiveField.value).toBe("0.95 DAI");
+      expect(receiveField.fieldType).toBe("uint");
+      expect(receiveField.format).toBe("tokenAmount");
+      expect(receiveField.tokenAddress).toBe(
+        toChecksumAddress(hexToBytes(DAI)),
+      );
+      expect(receiveField.embeddedCalldata).toBeUndefined();
+      expect(receiveField.rawAddress).toBeUndefined();
+      expect(receiveField.warning).toBeUndefined();
+
+      // Child 2: Beneficiary
+      const beneficiaryField = curveGroup.fields[2];
+      expect(beneficiaryField.label).toBe("Beneficiary");
+      expect(beneficiaryField.value).toBe("vitalik.eth");
+      expect(beneficiaryField.fieldType).toBe("address");
+      expect(beneficiaryField.format).toBe("addressName");
+      expect(beneficiaryField.rawAddress).toBe(
+        toChecksumAddress(hexToBytes(BENEFICIARY)),
       );
       expect(beneficiaryField.tokenAddress).toBeUndefined();
       expect(beneficiaryField.embeddedCalldata).toBeUndefined();


### PR DESCRIPTION
## Summary
- Adds a third routing branch in `fields.ts`: a field group whose `path` points to a static tuple (no `.[]` anywhere) now scopes its children's relative paths to that tuple — e.g. group `path: "#.swapData"` with child `path: "fromAmount"` resolves to `swapData.fromAmount`.
- The new `processStructGroup` always emits a `DisplayFieldGroup`; `label` may be undefined, leaving the rendering choice to the wallet UI.
- Previously, such groups returned an `EMPTY_ARRAY` warning because the only group-routing branches assumed array iteration. The pattern is used throughout the Paraswap AugustusSwapper v6.2 registry descriptor.
- Adds a `swapExactAmountInOnCurveV1` test in `test/registry-cases/paraswap/paraswap.spec.ts` exercising the new path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)