### PR TITLE
Support negative array indices in path resolution

### DIFF
--- a/src/calldata.ts
+++ b/src/calldata.ts
@@ -92,12 +92,16 @@ export async function formatCalldata(
     if (path.startsWith("@.")) return resolveTransactionPath(path, tx);
     if (path.startsWith("$."))
       return toArgumentValue(resolveMetadataValue(descriptor.metadata, path));
-    const key = path.startsWith("#.") ? path.slice(2) : path;
+    const stripped = path.startsWith("#.") ? path.slice(2) : path;
+    const key = normalizeNegativeIndices(stripped, decoded.arrayLengths);
+    if (key === undefined) return undefined;
     return decoded.values.get(key);
   };
 
   const getArrayLength = (path: string): number => {
-    const key = path.startsWith("#.") ? path.slice(2) : path;
+    const stripped = path.startsWith("#.") ? path.slice(2) : path;
+    const key = normalizeNegativeIndices(stripped, decoded.arrayLengths);
+    if (key === undefined) return 0;
     return decoded.arrayLengths.get(key) ?? 0;
   };
 
@@ -204,6 +208,32 @@ export function rawPreviewFromCalldata(
     selector: bytesToHex(selector),
     args,
   };
+}
+
+/**
+ * Rewrite negative array indices in a dot-path to absolute indices using the
+ * decoded array lengths. Per ERC-7730, `.[-N]` refers to the Nth element from
+ * the end of an array (so `.[-1]` is the last element). Returns `undefined`
+ * if any negative index has no matching array length or resolves out of bounds.
+ */
+function normalizeNegativeIndices(
+  path: string,
+  arrayLengths: Map<string, number>,
+): string | undefined {
+  if (!path.includes("[-")) return path;
+  const segments = path.split(".");
+  for (let i = 0; i < segments.length; i++) {
+    const match = segments[i].match(/^\[(-\d+)\]$/);
+    if (!match) continue;
+    const neg = parseInt(match[1], 10);
+    const prefix = segments.slice(0, i).join(".");
+    const length = arrayLengths.get(prefix);
+    if (length === undefined) return undefined;
+    const absIdx = length + neg;
+    if (absIdx < 0) return undefined;
+    segments[i] = `[${absIdx}]`;
+  }
+  return segments.join(".");
 }
 
 /** Find the format spec whose parsed function selector matches the given hex. */

--- a/src/eip712.ts
+++ b/src/eip712.ts
@@ -188,6 +188,7 @@ function collectReferencedTypes(
 /**
  * Navigate a dot-path in an EIP-712 message object.
  * Supports array index segments: `details.[0].amount` indexes into arrays.
+ * Negative indices count from the end: `.[-1]` selects the last element.
  */
 function getMessageValue(
   message: Record<string, unknown>,
@@ -196,10 +197,13 @@ function getMessageValue(
   let current: unknown = message;
   for (const segment of path.split(".")) {
     if (current === null || typeof current !== "object") return undefined;
-    const indexMatch = segment.match(/^\[(\d+)\]$/);
+    const indexMatch = segment.match(/^\[(-?\d+)\]$/);
     if (indexMatch) {
       if (!Array.isArray(current)) return undefined;
-      current = current[parseInt(indexMatch[1], 10)];
+      let idx = parseInt(indexMatch[1], 10);
+      if (idx < 0) idx += current.length;
+      if (idx < 0 || idx >= current.length) return undefined;
+      current = current[idx];
     } else {
       current = (current as Record<string, unknown>)[segment];
     }

--- a/test/registry-cases/lifi/calldata-LIFIDiamond.json
+++ b/test/registry-cases/lifi/calldata-LIFIDiamond.json
@@ -1,0 +1,533 @@
+{
+  "$schema": "https://github.com/LedgerHQ/clear-signing-erc7730-registry/blob/master/specs/erc7730-v2.schema.json",
+  "context": {
+    "$id": "LI.FI Service GmbH",
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 137,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 42161,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 10,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 56,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 43114,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 100,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 250,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 324,
+          "address": "0x341e94069f53234fE6DabeF707aD424830525715"
+        },
+        {
+          "chainId": 8453,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 59144,
+          "address": "0xDE1E598b81620773454588B85D6b5D4eEC32573e"
+        },
+        {
+          "chainId": 5000,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 534352,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 42220,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 1284,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 1285,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 1313161554,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 1088,
+          "address": "0x24ca98fB6972F5eE05f0dB00595c7f68D9FaFd68"
+        },
+        {
+          "chainId": 25,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 1666600000,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 122,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 288,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 106,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 9001,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 42170,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 167004,
+          "address": "0x3A9A5dBa8FE1C4Da98187cE4755701BCA182f63b"
+        },
+        {
+          "chainId": 204,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 81457,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 252,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        },
+        {
+          "chainId": 34443,
+          "address": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+        }
+      ]
+    }
+  },
+  "metadata": {
+    "owner": "LI.FI",
+    "info": { "url": "https://li.fi" },
+    "constants": {
+      "addressAsEth": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+      "addressAsNull": "0x0000000000000000000000000000000000000000"
+    },
+    "contractName": "LI.FI Service GmbH"
+  },
+  "display": {
+    "definitions": {
+      "fromAmount": {
+        "label": "Amount info",
+        "format": "tokenAmount",
+        "params": {
+          "nativeCurrencyAddress": [
+            "$.metadata.constants.addressAsEth",
+            "$.metadata.constants.addressAsNull"
+          ]
+        }
+      },
+      "_minAmountOut": {
+        "label": "Minimum Amount to receive",
+        "format": "tokenAmount",
+        "params": {
+          "nativeCurrencyAddress": [
+            "$.metadata.constants.addressAsEth",
+            "$.metadata.constants.addressAsNull"
+          ]
+        }
+      }
+    },
+    "formats": {
+      "swapTokensMultipleV3ERC20ToERC20(bytes32 _transactionId, string _integrator, string _referrer, address _receiver, uint256 _minAmountOut, (address callTo, address approveTo, address sendingAssetId, address receivingAssetId, uint256 fromAmount, bytes callData, bool requiresDeposit)[] _swapData)": {
+        "$id": "swapTokensMultipleV3ERC20ToERC20",
+        "intent": "Swap",
+        "fields": [
+          {
+            "path": "_swapData.[0].fromAmount",
+            "label": "Amount to Send",
+            "format": "tokenAmount",
+            "params": { "tokenPath": "_swapData.[0].sendingAssetId" },
+            "visible": "always"
+          },
+          {
+            "path": "_minAmountOut",
+            "label": "Minimum to Receive",
+            "format": "tokenAmount",
+            "params": { "tokenPath": "_swapData.[-1].receivingAssetId" },
+            "visible": "always"
+          },
+          {
+            "path": "_receiver",
+            "label": "Recipient",
+            "format": "addressName",
+            "params": {
+              "types": ["eoa", "contract"],
+              "sources": ["local", "ens"]
+            },
+            "visible": "always"
+          },
+          {
+            "label": "Transaction Id",
+            "path": "_transactionId",
+            "visible": "never"
+          },
+          { "label": "Integrator", "path": "_integrator", "visible": "never" },
+          { "label": "Referrer", "path": "_referrer", "visible": "never" },
+          {
+            "label": "Swap Data Call Data",
+            "path": "_swapData.[].callData",
+            "visible": "never"
+          },
+          {
+            "label": "Swap Data Call To",
+            "path": "_swapData.[].callTo",
+            "visible": "never"
+          },
+          {
+            "label": "Swap Data Approve To",
+            "path": "_swapData.[].approveTo",
+            "visible": "never"
+          },
+          {
+            "label": "Swap Data Requires Deposit",
+            "path": "_swapData.[].requiresDeposit",
+            "visible": "never"
+          }
+        ]
+      },
+      "swapTokensMultipleV3ERC20ToNative(bytes32 _transactionId, string _integrator, string _referrer, address _receiver, uint256 _minAmountOut, (address callTo, address approveTo, address sendingAssetId, address receivingAssetId, uint256 fromAmount, bytes callData, bool requiresDeposit)[] _swapData)": {
+        "$id": "swapTokensMultipleV3ERC20ToNative",
+        "intent": "Swap",
+        "fields": [
+          {
+            "path": "_swapData.[0].fromAmount",
+            "label": "Amount to Send",
+            "format": "tokenAmount",
+            "params": { "tokenPath": "_swapData.[0].sendingAssetId" },
+            "visible": "always"
+          },
+          {
+            "path": "_minAmountOut",
+            "$ref": "$.display.definitions._minAmountOut",
+            "visible": "always"
+          },
+          {
+            "path": "_receiver",
+            "label": "Receiver",
+            "format": "addressName",
+            "params": {
+              "types": ["eoa", "contract"],
+              "sources": ["local", "ens"]
+            },
+            "visible": "always"
+          },
+          {
+            "label": "Transaction Id",
+            "path": "_transactionId",
+            "visible": "never"
+          },
+          { "label": "Integrator", "path": "_integrator", "visible": "never" },
+          { "label": "Referrer", "path": "_referrer", "visible": "never" },
+          {
+            "label": "Swap Data Call Data",
+            "path": "_swapData.[].callData",
+            "visible": "never"
+          },
+          {
+            "label": "Swap Data Requires Deposit",
+            "path": "_swapData.[].requiresDeposit",
+            "visible": "never"
+          },
+          {
+            "label": "Swap Data Approve To",
+            "path": "_swapData.[].approveTo",
+            "visible": "never"
+          },
+          {
+            "label": "Swap Data Call To",
+            "path": "_swapData.[].callTo",
+            "visible": "never"
+          }
+        ]
+      },
+      "swapTokensMultipleV3NativeToERC20(bytes32 _transactionId, string _integrator, string _referrer, address _receiver, uint256 _minAmountOut, (address callTo, address approveTo, address sendingAssetId, address receivingAssetId, uint256 fromAmount, bytes callData, bool requiresDeposit)[] _swapData)": {
+        "$id": "swapTokensMultipleV3NativeToERC20",
+        "intent": "Swap",
+        "fields": [
+          { "path": "@.value", "label": "Amount to send", "format": "amount" },
+          {
+            "path": "_minAmountOut",
+            "label": "Minimum to Receive",
+            "format": "tokenAmount",
+            "params": { "tokenPath": "_swapData.[-1].receivingAssetId" },
+            "visible": "always"
+          },
+          {
+            "path": "_receiver",
+            "label": "Recipient",
+            "format": "addressName",
+            "params": {
+              "types": ["eoa", "contract"],
+              "sources": ["local", "ens"]
+            },
+            "visible": "always"
+          },
+          {
+            "label": "Transaction Id",
+            "path": "_transactionId",
+            "visible": "never"
+          },
+          { "label": "Integrator", "path": "_integrator", "visible": "never" },
+          { "label": "Referrer", "path": "_referrer", "visible": "never" },
+          {
+            "label": "Swap Data [0] Call Data",
+            "path": "_swapData.[0].callData",
+            "visible": "never"
+          },
+          {
+            "label": "Swap Data [0] Requires Deposit",
+            "path": "_swapData.[0].requiresDeposit",
+            "visible": "never"
+          },
+          {
+            "label": "Swap Data [0] Call To",
+            "path": "_swapData.[0].callTo",
+            "visible": "never"
+          },
+          {
+            "label": "Swap Data [0] Approve To",
+            "path": "_swapData.[0].approveTo",
+            "visible": "never"
+          }
+        ]
+      },
+      "swapTokensSingleV3ERC20ToERC20(bytes32 _transactionId, string _integrator, string _referrer, address _receiver, uint256 _minAmountOut, (address callTo, address approveTo, address sendingAssetId, address receivingAssetId, uint256 fromAmount, bytes callData, bool requiresDeposit) _swapData)": {
+        "$id": "swapTokensSingleV3ERC20ToERC20",
+        "intent": "Swap",
+        "fields": [
+          {
+            "path": "_swapData.fromAmount",
+            "label": "Amount to Send",
+            "format": "tokenAmount",
+            "params": { "tokenPath": "_swapData.sendingAssetId" },
+            "visible": "always"
+          },
+          {
+            "path": "_minAmountOut",
+            "label": "Minimum to Receive",
+            "format": "tokenAmount",
+            "params": { "tokenPath": "_swapData.receivingAssetId" },
+            "visible": "always"
+          },
+          {
+            "path": "_receiver",
+            "label": "Recipient",
+            "format": "addressName",
+            "params": {
+              "types": ["eoa", "contract"],
+              "sources": ["local", "ens"]
+            },
+            "visible": "always"
+          },
+          {
+            "label": "Transaction Id",
+            "path": "_transactionId",
+            "visible": "never"
+          },
+          { "label": "Integrator", "path": "_integrator", "visible": "never" },
+          { "label": "Referrer", "path": "_referrer", "visible": "never" },
+          {
+            "label": "Swap Data Call Data",
+            "path": "_swapData.callData",
+            "visible": "never"
+          },
+          {
+            "label": "Swap Data Requires Deposit",
+            "path": "_swapData.requiresDeposit",
+            "visible": "never"
+          }
+        ]
+      },
+      "swapTokensSingleV3ERC20ToNative(bytes32 _transactionId, string _integrator, string _referrer, address _receiver, uint256 _minAmountOut, (address callTo, address approveTo, address sendingAssetId, address receivingAssetId, uint256 fromAmount, bytes callData, bool requiresDeposit) _swapData)": {
+        "$id": "swapTokensSingleV3ERC20ToNative",
+        "intent": "Swap",
+        "fields": [
+          {
+            "path": "_swapData.fromAmount",
+            "label": "Amount to Send",
+            "format": "tokenAmount",
+            "params": { "tokenPath": "_swapData.sendingAssetId" },
+            "visible": "always"
+          },
+          {
+            "path": "_minAmountOut",
+            "$ref": "$.display.definitions._minAmountOut",
+            "visible": "always"
+          },
+          {
+            "path": "_receiver",
+            "label": "Receiver",
+            "format": "addressName",
+            "params": {
+              "types": ["eoa", "contract"],
+              "sources": ["local", "ens"]
+            },
+            "visible": "always"
+          },
+          {
+            "label": "Transaction Id",
+            "path": "_transactionId",
+            "visible": "never"
+          },
+          { "label": "Integrator", "path": "_integrator", "visible": "never" },
+          { "label": "Referrer", "path": "_referrer", "visible": "never" },
+          {
+            "label": "Swap Data Call Data",
+            "path": "_swapData.callData",
+            "visible": "never"
+          },
+          {
+            "label": "Swap Data Call To",
+            "path": "_swapData.callTo",
+            "visible": "never"
+          },
+          {
+            "label": "Swap Data Approve To",
+            "path": "_swapData.approveTo",
+            "visible": "never"
+          },
+          {
+            "label": "Swap Data Requires Deposit",
+            "path": "_swapData.requiresDeposit",
+            "visible": "never"
+          }
+        ]
+      },
+      "swapTokensSingleV3NativeToERC20(bytes32 _transactionId, string _integrator, string _referrer, address _receiver, uint256 _minAmountOut, (address callTo, address approveTo, address sendingAssetId, address receivingAssetId, uint256 fromAmount, bytes callData, bool requiresDeposit) _swapData)": {
+        "$id": "swapTokensSingleV3NativeToERC20",
+        "intent": "Swap",
+        "fields": [
+          { "path": "@.value", "label": "Amount to send", "format": "amount" },
+          {
+            "path": "_minAmountOut",
+            "label": "Minimum to Receive",
+            "format": "tokenAmount",
+            "params": { "tokenPath": "_swapData.receivingAssetId" },
+            "visible": "always"
+          },
+          {
+            "path": "_receiver",
+            "label": "Recipient",
+            "format": "addressName",
+            "params": {
+              "types": ["eoa", "contract"],
+              "sources": ["local", "ens"]
+            },
+            "visible": "always"
+          },
+          {
+            "label": "Transaction Id",
+            "path": "_transactionId",
+            "visible": "never"
+          },
+          { "label": "Integrator", "path": "_integrator", "visible": "never" },
+          { "label": "Referrer", "path": "_referrer", "visible": "never" },
+          {
+            "label": "Swap Data Call Data",
+            "path": "_swapData.callData",
+            "visible": "never"
+          },
+          {
+            "label": "Swap Data Requires Deposit",
+            "path": "_swapData.requiresDeposit",
+            "visible": "never"
+          },
+          {
+            "label": "Swap Data Approve To",
+            "path": "_swapData.approveTo",
+            "visible": "never"
+          }
+        ]
+      },
+      "swapTokensGeneric(bytes32 _transactionId, string _integrator, string _referrer, address _receiver, uint256 _minAmount, (address callTo, address approveTo, address sendingAssetId, address receivingAssetId, uint256 fromAmount, bytes callData, bool requiresDeposit)[] _swapData)": {
+        "$id": "swapTokensGeneric",
+        "intent": "Swap",
+        "fields": [
+          {
+            "path": "_swapData.[0].fromAmount",
+            "label": "Amount to Send",
+            "format": "tokenAmount",
+            "params": { "tokenPath": "_swapData.[0].sendingAssetId" },
+            "visible": "always"
+          },
+          {
+            "path": "_minAmount",
+            "label": "Minimum to Receive",
+            "format": "tokenAmount",
+            "params": { "tokenPath": "_swapData.[-1].receivingAssetId" },
+            "visible": "always"
+          },
+          {
+            "path": "_receiver",
+            "label": "Recipient",
+            "format": "addressName",
+            "params": {
+              "types": ["eoa", "contract"],
+              "sources": ["local", "ens"]
+            },
+            "visible": "always"
+          },
+          {
+            "label": "Transaction Id",
+            "path": "_transactionId",
+            "visible": "never"
+          },
+          { "label": "Integrator", "path": "_integrator", "visible": "never" },
+          { "label": "Referrer", "path": "_referrer", "visible": "never" },
+          {
+            "label": "Swap Data Call Data",
+            "path": "_swapData.[].callData",
+            "visible": "never"
+          },
+          {
+            "label": "Swap Data Call To",
+            "path": "_swapData.[].callTo",
+            "visible": "never"
+          },
+          {
+            "label": "Swap Data Approve To",
+            "path": "_swapData.[].approveTo",
+            "visible": "never"
+          },
+          {
+            "label": "Swap Data Requires Deposit",
+            "path": "_swapData.[].requiresDeposit",
+            "visible": "never"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/registry-cases/lifi/lifi.spec.ts
+++ b/test/registry-cases/lifi/lifi.spec.ts
@@ -1,0 +1,190 @@
+/**
+ * Tests for LI.FI LIFIDiamond descriptor:
+ * - swapTokensMultipleV3ERC20ToERC20: dynamic tuple array with array-indexed
+ *   token paths (_swapData.[0].sendingAssetId, _swapData.[-1].receivingAssetId).
+ */
+
+import { describe, it, expect, assert } from "vitest";
+import { format, isFieldGroup } from "../../../src/index.js";
+import type { DisplayModel, ExternalDataProvider } from "../../../src/types.js";
+import { hexToBytes, toChecksumAddress } from "../../../src/utils.js";
+import { buildEmbeddedResolverOpts } from "../../utils.js";
+
+describe("LI.FI LIFIDiamond", () => {
+  const CHAIN_ID = 1;
+  const CONTRACT = "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE";
+  const FROM = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
+  const BENEFICIARY = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
+
+  const USDC = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
+  const DAI = "0x6b175474e89094c44da98b954eedeac495271d0f";
+  // WETH (0xc02a...cc2) is the intermediate hop; appears only in raw calldata.
+
+  const resolveToken: ExternalDataProvider["resolveToken"] = async (
+    chainId,
+    tokenAddress,
+  ) => {
+    if (chainId === CHAIN_ID && tokenAddress === USDC) {
+      return { name: "USD Coin", symbol: "USDC", decimals: 6 };
+    }
+    if (chainId === CHAIN_ID && tokenAddress === DAI) {
+      return { name: "Dai Stablecoin", symbol: "DAI", decimals: 18 };
+    }
+    return null;
+  };
+
+  const resolveLocalName: ExternalDataProvider["resolveLocalName"] = async (
+    address,
+  ) => {
+    if (address === BENEFICIARY.toLowerCase()) {
+      return { name: "vitalik.eth", typeMatch: true };
+    }
+    return null;
+  };
+
+  function buildOpts(externalDataProvider?: ExternalDataProvider) {
+    return buildEmbeddedResolverOpts(
+      __dirname,
+      {
+        calldataDescriptorFiles: [
+          {
+            chainId: CHAIN_ID,
+            address: CONTRACT,
+            file: "calldata-LIFIDiamond.json",
+          },
+        ],
+      },
+      externalDataProvider,
+    );
+  }
+
+  // =========================================================================
+  // swapTokensMultipleV3ERC20ToERC20
+  // =========================================================================
+  describe("swapTokensMultipleV3ERC20ToERC20", () => {
+    // Two-hop swap: 1000 USDC → WETH (intermediate) → DAI (min 950 DAI out).
+    //
+    // Signature: swapTokensMultipleV3ERC20ToERC20(
+    //   bytes32 _transactionId, string _integrator, string _referrer,
+    //   address _receiver, uint256 _minAmountOut,
+    //   (address callTo, address approveTo, address sendingAssetId,
+    //    address receivingAssetId, uint256 fromAmount, bytes callData,
+    //    bool requiresDeposit)[] _swapData
+    // )
+    // Selector: 0x5fd9ae2e
+    //
+    // The tuple is dynamic (contains `bytes callData`), so the array element
+    // offsets are required even though there are only two elements.
+    const SWAP_CALLDATA =
+      "0x5fd9ae2e" +
+      // --- head (6 words) ---
+      "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" + // _transactionId
+      "00000000000000000000000000000000000000000000000000000000000000c0" + // _integrator offset = 0xc0
+      "0000000000000000000000000000000000000000000000000000000000000100" + // _referrer offset = 0x100
+      "000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045" + // _receiver
+      "0000000000000000000000000000000000000000000000337fe5feaf2d180000" + // _minAmountOut = 950e18
+      "0000000000000000000000000000000000000000000000000000000000000120" + // _swapData offset = 0x120
+      // --- _integrator: "lifi-api" ---
+      "0000000000000000000000000000000000000000000000000000000000000008" + // length = 8
+      "6c6966692d617069000000000000000000000000000000000000000000000000" + // "lifi-api" padded
+      // --- _referrer: "" ---
+      "0000000000000000000000000000000000000000000000000000000000000000" + // length = 0
+      // --- _swapData (length=2) ---
+      "0000000000000000000000000000000000000000000000000000000000000002" + // length
+      "0000000000000000000000000000000000000000000000000000000000000040" + // element 0 offset (from after length)
+      "0000000000000000000000000000000000000000000000000000000000000140" + // element 1 offset
+      // --- element 0: USDC → WETH ---
+      "0000000000000000000000001111111111111111111111111111111111111111" + // callTo
+      "0000000000000000000000001111111111111111111111111111111111111111" + // approveTo
+      "000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48" + // sendingAssetId = USDC
+      "000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2" + // receivingAssetId = WETH
+      "000000000000000000000000000000000000000000000000000000003b9aca00" + // fromAmount = 1e9 (1000 USDC)
+      "00000000000000000000000000000000000000000000000000000000000000e0" + // callData offset = 0xe0
+      "0000000000000000000000000000000000000000000000000000000000000000" + // requiresDeposit = false
+      "0000000000000000000000000000000000000000000000000000000000000000" + // callData length = 0
+      // --- element 1: WETH → DAI ---
+      "0000000000000000000000001111111111111111111111111111111111111111" + // callTo
+      "0000000000000000000000001111111111111111111111111111111111111111" + // approveTo
+      "000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2" + // sendingAssetId = WETH
+      "0000000000000000000000006b175474e89094c44da98b954eedeac495271d0f" + // receivingAssetId = DAI
+      "0000000000000000000000000000000000000000000000000000000000000000" + // fromAmount = 0 (unused by display)
+      "00000000000000000000000000000000000000000000000000000000000000e0" + // callData offset = 0xe0
+      "0000000000000000000000000000000000000000000000000000000000000000" + // requiresDeposit = false
+      "0000000000000000000000000000000000000000000000000000000000000000"; // callData length = 0
+
+    it("formats a two-hop ERC20→ERC20 swap with array-indexed token paths", async () => {
+      const opts = buildOpts({ resolveToken, resolveLocalName });
+
+      const result: DisplayModel = await format(
+        {
+          chainId: CHAIN_ID,
+          to: CONTRACT,
+          from: FROM,
+          data: SWAP_CALLDATA,
+        },
+        opts,
+      );
+
+      expect(result.intent).toBe("Swap");
+
+      assert(result.fields);
+      // Visible: Amount to Send, Minimum to Receive, Recipient
+      // Hidden (visible=never): _transactionId, _integrator, _referrer,
+      //   _swapData.[].callData, .callTo, .approveTo, .requiresDeposit
+      expect(result.fields).toHaveLength(3);
+
+      // Field 0: Amount to Send — tokenAmount from _swapData.[0].fromAmount
+      // with tokenPath _swapData.[0].sendingAssetId resolving to USDC
+      const sendField = result.fields[0];
+      assert(!isFieldGroup(sendField));
+      expect(sendField.label).toBe("Amount to Send");
+      expect(sendField.value).toBe("1000 USDC");
+      expect(sendField.fieldType).toBe("uint");
+      expect(sendField.format).toBe("tokenAmount");
+      expect(sendField.tokenAddress).toBe(toChecksumAddress(hexToBytes(USDC)));
+      expect(sendField.embeddedCalldata).toBeUndefined();
+      expect(sendField.rawAddress).toBeUndefined();
+      expect(sendField.warning).toBeUndefined();
+
+      // Field 1: Minimum to Receive — tokenAmount from _minAmountOut with
+      // tokenPath _swapData.[-1].receivingAssetId resolving to the last
+      // element's receivingAssetId = DAI
+      const receiveField = result.fields[1];
+      assert(!isFieldGroup(receiveField));
+      expect(receiveField.label).toBe("Minimum to Receive");
+      expect(receiveField.value).toBe("950 DAI");
+      expect(receiveField.fieldType).toBe("uint");
+      expect(receiveField.format).toBe("tokenAmount");
+      expect(receiveField.tokenAddress).toBe(
+        toChecksumAddress(hexToBytes(DAI)),
+      );
+      expect(receiveField.embeddedCalldata).toBeUndefined();
+      expect(receiveField.rawAddress).toBeUndefined();
+      expect(receiveField.warning).toBeUndefined();
+
+      // Field 2: Recipient — addressName resolved from _receiver
+      const recipientField = result.fields[2];
+      assert(!isFieldGroup(recipientField));
+      expect(recipientField.label).toBe("Recipient");
+      expect(recipientField.value).toBe("vitalik.eth");
+      expect(recipientField.fieldType).toBe("address");
+      expect(recipientField.format).toBe("addressName");
+      expect(recipientField.rawAddress).toBe(
+        toChecksumAddress(hexToBytes(BENEFICIARY)),
+      );
+      expect(recipientField.tokenAddress).toBeUndefined();
+      expect(recipientField.embeddedCalldata).toBeUndefined();
+      expect(recipientField.warning).toBeUndefined();
+
+      // Metadata
+      assert(result.metadata);
+      expect(result.metadata.owner).toBe("LI.FI");
+      expect(result.metadata.contractName).toBe("LI.FI Service GmbH");
+      expect(result.metadata.info).toEqual({ url: "https://li.fi" });
+
+      expect(result.interpolatedIntent).toBeUndefined();
+      expect(result.rawCalldataFallback).toBeUndefined();
+      expect(result.warnings).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Calldata decoder rewrites `.[-N]` path segments to absolute indices using the decoded array lengths before lookup, so descriptors using `_swapData.[-1].receivingAssetId` and similar work as intended.
- EIP-712 `getMessageValue` accepts negative index segments and wraps them against the live array length.
- Adds a registry test case for LI.FI LIFIDiamond `swapTokensMultipleV3ERC20ToERC20`, which depends on `_swapData.[-1].receivingAssetId` for its `Minimum to Receive` token path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)