### PR TITLE
Resolve descriptor includes recursively

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,7 +184,9 @@ Pure I/O layer with no caching. Exports:
 
 ## Descriptor Includes & Merging
 
-ERC-7730 descriptors may reference another descriptor file via a top-level `includes` field containing a relative path. `DescriptorResolver` automatically fetches and merges the included file before returning the descriptor.
+ERC-7730 descriptors may reference another descriptor file via a top-level `includes` field containing a relative path. `DescriptorResolver` automatically fetches and merges the included file before returning the descriptor. Includes may be chained — each included descriptor is resolved with its own includes before being merged upward. A cyclic include chain returns a `CYCLIC_INCLUDES` warning rather than throwing.
+
+`resolveCalldataDescriptor` / `resolveTypedDataDescriptor` return `Promise<{ descriptor } | { warning }>`. The warning is `NO_DESCRIPTOR` when nothing is indexed for the lookup key, or `CYCLIC_INCLUDES` when the include chain self-references. Fetch errors from the underlying descriptor I/O still throw — only resolution-logic failures surface as warnings.
 
 The merge is implemented in `mergeDescriptors(including, included)` (internal to `resolver.ts`) and follows the EIP-7730 spec:
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,7 @@ export { isFieldGroup } from "./utils.js";
 export {
   resolveCalldataDescriptor,
   resolveTypedDataDescriptor,
+  mergeDescriptors,
 } from "./resolver.js";
 
 /** EIP-712 utility helpers. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,6 @@ import {
 } from "./eip712.js";
 import { warn } from "./utils.js";
 import type {
-  Descriptor,
   DisplayModel,
   FormatOptions,
   FormatCalldata,
@@ -41,6 +40,7 @@ import type {
   BatchDisplayModel,
   Eip5792Batch,
   Warning,
+  Descriptor,
 } from "./types.js";
 
 export type * from "./types.js";
@@ -76,13 +76,29 @@ export async function format(
   opts?: FormatOptions,
 ): Promise<DisplayModel> {
   try {
-    let descriptor: Descriptor | undefined;
+    let descriptor: Descriptor;
     try {
-      descriptor = await resolveCalldataDescriptor(
+      const result = await resolveCalldataDescriptor(
         tx.chainId,
         tx.to,
         opts?.descriptorResolverOptions,
       );
+
+      if ("warning" in result) {
+        const parsed = parseCalldataHex(tx.data);
+        if ("warning" in parsed) {
+          return { warnings: [result.warning, parsed.warning] };
+        }
+        return {
+          rawCalldataFallback: rawPreviewFromCalldata(
+            parsed.selector,
+            parsed.calldata,
+          ),
+          warnings: [result.warning],
+        };
+      } else {
+        descriptor = result.descriptor;
+      }
     } catch (error) {
       return {
         warnings: [
@@ -91,26 +107,6 @@ export async function format(
             `Failed to resolve descriptor for chain ${tx.chainId} and address ${tx.to}: ${String(error)}`,
           ),
         ],
-      };
-    }
-
-    if (!descriptor) {
-      const noDescriptor = warn(
-        "NO_DESCRIPTOR",
-        `No descriptor found for chain ${tx.chainId} and address ${tx.to}`,
-      );
-
-      const parsed = parseCalldataHex(tx.data);
-      if ("warning" in parsed) {
-        return { warnings: [noDescriptor, parsed.warning] };
-      }
-
-      return {
-        rawCalldataFallback: rawPreviewFromCalldata(
-          parsed.selector,
-          parsed.calldata,
-        ),
-        warnings: [noDescriptor],
       };
     }
 
@@ -242,29 +238,23 @@ export async function formatTypedData(
       };
     }
 
-    let descriptor: Descriptor | undefined;
+    let descriptor: Descriptor;
     try {
-      descriptor = await resolveTypedDataDescriptor(
+      const result = await resolveTypedDataDescriptor(
         typedData,
         opts?.descriptorResolverOptions,
       );
+      if ("warning" in result) {
+        return { warnings: [result.warning] };
+      } else {
+        descriptor = result.descriptor;
+      }
     } catch (error) {
       return {
         warnings: [
           warn(
             "DESCRIPTOR_FETCH_ERROR",
             `Failed to resolve descriptor for chain ${chainId} and address ${verifyingContract}: ${String(error)}`,
-          ),
-        ],
-      };
-    }
-
-    if (!descriptor) {
-      return {
-        warnings: [
-          warn(
-            "NO_DESCRIPTOR",
-            `No descriptor found for chain ${chainId} and address ${verifyingContract}`,
           ),
         ],
       };

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -170,6 +170,8 @@ async function resolveWithIncludes(
 /**
  * Merges an including ERC-7730 descriptor with the descriptor it includes.
  *
+ * May be useful for creating indexes, and correctly resolving an includes chain.
+ *
  * Implements the EIP-7730 merge algorithm:
  * - The including descriptor takes priority over the included descriptor for all unique keys.
  * - `fields` arrays within display format entries are merged by path value:
@@ -177,7 +179,7 @@ async function resolveWithIncludes(
  *   and new fields are appended.
  * - The `includes` key itself is not carried over to the merged result.
  */
-function mergeDescriptors(
+export function mergeDescriptors(
   including: Descriptor,
   included: Descriptor,
 ): Descriptor {

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -12,12 +12,14 @@ import type {
   GitHubSource,
   RegistryIndex,
   TypedData,
+  Warning,
 } from "./types.js";
 import {
   asciiToBytes,
   bytesToHex,
   keccak256,
   normalizeAddress,
+  warn,
 } from "./utils.js";
 
 /**
@@ -29,6 +31,10 @@ interface Resolver {
   index: RegistryIndex;
   fetchDescriptor: (path: string) => Promise<Descriptor>;
 }
+
+type ResolveDescriptorResult =
+  | { descriptor: Descriptor }
+  | { warning: Warning };
 
 /**
  * Builds a {@link Resolver} for the given source. For `"github"` without an
@@ -67,16 +73,21 @@ async function createResolver(
   }
 }
 
-/** Resolves a calldata descriptor by `(chainId, contractAddress)`. */
+/**
+ * Resolves a calldata descriptor by `(chainId, contractAddress)`. Returns
+ * a `{ descriptor }` envelope on success, or a `{ warning }` envelope when
+ * resolution fails — `NO_DESCRIPTOR` when nothing is indexed for the pair,
+ * `CYCLIC_INCLUDES` when the `includes` chain self-references.
+ */
 export async function resolveCalldataDescriptor(
   chainId: number,
   to: string,
   options?: GitHubResolverOptions | EmbeddedResolverOptions,
-): Promise<Descriptor | undefined> {
+): Promise<ResolveDescriptorResult> {
   const resolver = await createResolver(options);
   const path =
     resolver.index.calldataIndex[`eip155:${chainId}:${normalizeAddress(to)}`];
-  if (!path) return undefined;
+  if (!path) return noDescriptorWarning(chainId, to);
   return resolveWithIncludes(resolver, path);
 }
 
@@ -85,15 +96,18 @@ export async function resolveCalldataDescriptor(
  *
  * Looks up candidates by `(chainId, verifyingContract, primaryType)`, then
  * picks the entry whose `encodeTypeHashes` contain the keccak256 hash of
- * the message's EIP-712 `encodeType` string. Returns `undefined` when no
- * candidate matches the computed hash.
+ * the message's EIP-712 `encodeType` string. Returns `NO_DESCRIPTOR` if no
+ * candidate matches, `CYCLIC_INCLUDES` if the `includes` chain self-references,
+ * or `{ descriptor }` on success.
  */
 export async function resolveTypedDataDescriptor(
   typedData: TypedData,
   options?: GitHubResolverOptions | EmbeddedResolverOptions,
-): Promise<Descriptor | undefined> {
+): Promise<ResolveDescriptorResult> {
   const { chainId, verifyingContract } = typedData.domain;
-  if (chainId === undefined || !verifyingContract) return undefined;
+  if (chainId === undefined || !verifyingContract) {
+    return noDescriptorWarning(chainId, verifyingContract);
+  }
 
   const resolver = await createResolver(options);
   const byPrimaryType =
@@ -101,32 +115,56 @@ export async function resolveTypedDataDescriptor(
       `eip155:${chainId}:${normalizeAddress(verifyingContract)}`
     ];
   const entries = byPrimaryType?.[typedData.primaryType];
-  if (!entries?.length) return undefined;
+  if (!entries?.length) return noDescriptorWarning(chainId, verifyingContract);
 
   const encodeTypeStr = computeEncodeType(
     typedData.primaryType,
     typedData.types,
   );
-  if (!encodeTypeStr) return undefined;
+  if (!encodeTypeStr) return noDescriptorWarning(chainId, verifyingContract);
   const hash = bytesToHex(keccak256(asciiToBytes(encodeTypeStr)));
 
   const match = entries.find((e) => e.encodeTypeHashes.includes(hash));
-  if (!match) return undefined;
+  if (!match) return noDescriptorWarning(chainId, verifyingContract);
   return resolveWithIncludes(resolver, match.path);
+}
+
+function noDescriptorWarning(
+  chainId: number | undefined,
+  address: string | undefined,
+): ResolveDescriptorResult {
+  return {
+    warning: warn(
+      "NO_DESCRIPTOR",
+      `No descriptor found for chain ${chainId} and address ${address}`,
+    ),
+  };
 }
 
 async function resolveWithIncludes(
   resolver: Resolver,
   path: string,
-): Promise<Descriptor> {
+  visited: Set<string> = new Set(),
+): Promise<ResolveDescriptorResult> {
+  if (visited.has(path)) {
+    return {
+      warning: warn(
+        "CYCLIC_INCLUDES",
+        `Cyclic includes detected for descriptor path '${path}'`,
+      ),
+    };
+  }
+  visited.add(path);
+
   const descriptor = await resolver.fetchDescriptor(path);
   const includes =
     typeof descriptor.includes === "string" ? descriptor.includes : undefined;
-  if (!includes) return descriptor;
+  if (!includes) return { descriptor };
 
   const includesPath = new URL(includes, `https://x/${path}`).pathname.slice(1);
-  const included = await resolver.fetchDescriptor(includesPath);
-  return mergeDescriptors(descriptor, included);
+  const included = await resolveWithIncludes(resolver, includesPath, visited);
+  if ("warning" in included) return included;
+  return { descriptor: mergeDescriptors(descriptor, included.descriptor) };
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -103,7 +103,8 @@ export type WarningCode =
   | "BATCH_VALUE_TRANSFER"
   | "BATCH_CONTRACT_CREATION"
   | "BATCH_INTERPOLATION_INCOMPLETE"
-  | "BATCH_EMPTY";
+  | "BATCH_EMPTY"
+  | "CYCLIC_INCLUDES";
 
 /** Warning from formatting. */
 export interface Warning {

--- a/test/registry-cases/kiln/calldata-Vault-USDT-Aave-v3.json
+++ b/test/registry-cases/kiln/calldata-Vault-USDT-Aave-v3.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "../../specs/erc7730-v2.schema.json",
+  "includes": "common-KilnVaults.json",
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0xdD7927c757c1659B56C81c65af848Ae400EB879D"
+        }
+      ]
+    }
+  },
+  "metadata": {
+    "constants": {
+      "underlyingToken": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+      "underlyingTicker": "USDT",
+      "vaultTicker": "kAaveUSDT"
+    }
+  }
+}

--- a/test/registry-cases/kiln/common-KilnVaults.json
+++ b/test/registry-cases/kiln/common-KilnVaults.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../specs/erc7730-v2.schema.json",
+  "includes": "ercs/calldata-erc4626-vaults.json",
+  "metadata": {
+    "owner": "Kiln",
+    "info": {
+      "url": "https://kiln.fi/"
+    }
+  }
+}

--- a/test/registry-cases/kiln/ercs/calldata-erc4626-vaults.json
+++ b/test/registry-cases/kiln/ercs/calldata-erc4626-vaults.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "../../specs/erc7730-v2.schema.json",
+  "context": { "contract": {} },
+  "metadata": { "constants": { "underlyingToken": "0x0" } },
+  "display": {
+    "formats": {
+      "deposit(uint256 assets, address receiver)": {
+        "intent": "Deposit",
+        "fields": [
+          {
+            "path": "assets",
+            "label": "Deposit asset",
+            "format": "tokenAmount",
+            "params": { "token": "$.metadata.constants.underlyingToken" },
+            "visible": "always"
+          },
+          {
+            "label": "Share ticker",
+            "format": "raw",
+            "value": "$.metadata.constants.vaultTicker"
+          },
+          {
+            "path": "receiver",
+            "label": "Send shares to",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] },
+            "visible": "always"
+          }
+        ]
+      },
+      "mint(uint256 shares, address receiver)": {
+        "intent": "Mint",
+        "fields": [
+          {
+            "label": "Deposit asset",
+            "format": "raw",
+            "value": "$.metadata.constants.underlyingTicker"
+          },
+          {
+            "path": "shares",
+            "label": "Minted shares",
+            "format": "tokenAmount",
+            "params": { "tokenPath": "@.to" },
+            "visible": "always"
+          },
+          {
+            "path": "receiver",
+            "label": "Mint shares to",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] },
+            "visible": "always"
+          }
+        ]
+      },
+      "withdraw(uint256 assets, address receiver, address owner)": {
+        "intent": "Withdraw",
+        "fields": [
+          {
+            "path": "assets",
+            "label": "Withdraw exactly",
+            "format": "tokenAmount",
+            "params": { "token": "$.metadata.constants.underlyingToken" },
+            "visible": "always"
+          },
+          {
+            "path": "receiver",
+            "label": "To",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] },
+            "visible": "always"
+          },
+          {
+            "path": "owner",
+            "label": "Owner",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] },
+            "visible": "always"
+          }
+        ]
+      },
+      "redeem(uint256 shares, address receiver, address owner)": {
+        "intent": "Redeem",
+        "fields": [
+          {
+            "path": "shares",
+            "label": "Shares to redeem",
+            "format": "tokenAmount",
+            "params": { "tokenPath": "@.to" },
+            "visible": "always"
+          },
+          {
+            "path": "receiver",
+            "label": "To",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] },
+            "visible": "always"
+          },
+          {
+            "path": "owner",
+            "label": "Owner",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] },
+            "visible": "always"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/registry-cases/kiln/kiln.spec.ts
+++ b/test/registry-cases/kiln/kiln.spec.ts
@@ -1,0 +1,134 @@
+/**
+ * Tests for the Kiln USDT Aave v3 vault descriptor:
+ * - ERC-4626 deposit, with the format spec inherited through two levels
+ *   of includes:
+ *     calldata-Vault-USDT-Aave-v3.json
+ *       └─ common-KilnVaults.json
+ *            └─ ercs/calldata-erc4626-vaults.json
+ */
+
+import { describe, it, expect, assert } from "vitest";
+import { format, isFieldGroup } from "../../../src/index.js";
+import type { ExternalDataProvider } from "../../../src/types.js";
+import { hexToBytes, toChecksumAddress } from "../../../src/utils.js";
+import { buildEmbeddedResolverOpts } from "../../utils.js";
+
+describe("Kiln Vault USDT Aave v3", () => {
+  const CHAIN_ID = 1;
+  const VAULT = "0xdD7927c757c1659B56C81c65af848Ae400EB879D";
+  const USDT = "0xdAC17F958D2ee523a2206206994597C13D831ec7";
+  const FROM = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
+  const RECEIVER = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
+
+  const resolveToken: ExternalDataProvider["resolveToken"] = async (
+    chainId,
+    tokenAddress,
+  ) => {
+    if (chainId === CHAIN_ID && tokenAddress === USDT.toLowerCase()) {
+      return { name: "Tether USD", symbol: "USDT", decimals: 6 };
+    }
+    return null;
+  };
+
+  const resolveLocalName: ExternalDataProvider["resolveLocalName"] = async (
+    address,
+  ) => {
+    if (address === RECEIVER.toLowerCase()) {
+      return { name: "vitalik.eth", typeMatch: true };
+    }
+    return null;
+  };
+
+  function buildOpts(externalDataProvider?: ExternalDataProvider) {
+    return buildEmbeddedResolverOpts(
+      __dirname,
+      {
+        calldataDescriptorFiles: [
+          {
+            chainId: CHAIN_ID,
+            address: VAULT,
+            file: "calldata-Vault-USDT-Aave-v3.json",
+          },
+        ],
+      },
+      externalDataProvider,
+    );
+  }
+
+  it("formats a deposit using the format inherited from the ERC-4626 include", async () => {
+    // deposit(uint256 assets, address receiver), selector 0x6e553f65
+    // assets = 100_000_000 (100 USDT), receiver = vitalik.eth address
+    const DEPOSIT_CALLDATA =
+      "0x6e553f65" +
+      "0000000000000000000000000000000000000000000000000000000005f5e100" + // assets = 100e6
+      "000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045"; // receiver
+
+    const opts = buildOpts({ resolveToken, resolveLocalName });
+
+    const result = await format(
+      {
+        chainId: CHAIN_ID,
+        to: VAULT,
+        from: FROM,
+        data: DEPOSIT_CALLDATA,
+      },
+      opts,
+    );
+
+    expect(result.intent).toBe("Deposit");
+
+    assert(result.fields);
+    // Visible fields: Deposit asset (tokenAmount), Share ticker (raw constant),
+    //                 Send shares to (addressName)
+    expect(result.fields).toHaveLength(3);
+
+    // Field 0: Deposit asset — tokenAmount with token from
+    // $.metadata.constants.underlyingToken (USDT)
+    const assetField = result.fields[0];
+    assert(!isFieldGroup(assetField));
+    expect(assetField.label).toBe("Deposit asset");
+    expect(assetField.value).toBe("100 USDT");
+    expect(assetField.fieldType).toBe("uint");
+    expect(assetField.format).toBe("tokenAmount");
+    expect(assetField.tokenAddress).toBe(toChecksumAddress(hexToBytes(USDT)));
+    expect(assetField.embeddedCalldata).toBeUndefined();
+    expect(assetField.rawAddress).toBeUndefined();
+    expect(assetField.warning).toBeUndefined();
+
+    // Field 1: Share ticker — raw constant from $.metadata.constants.vaultTicker
+    const tickerField = result.fields[1];
+    assert(!isFieldGroup(tickerField));
+    expect(tickerField.label).toBe("Share ticker");
+    expect(tickerField.value).toBe("kAaveUSDT");
+    expect(tickerField.fieldType).toBe("string");
+    expect(tickerField.format).toBe("raw");
+    expect(tickerField.tokenAddress).toBeUndefined();
+    expect(tickerField.rawAddress).toBeUndefined();
+    expect(tickerField.embeddedCalldata).toBeUndefined();
+    expect(tickerField.warning).toBeUndefined();
+
+    // Field 2: Send shares to — addressName for the receiver
+    const receiverField = result.fields[2];
+    assert(!isFieldGroup(receiverField));
+    expect(receiverField.label).toBe("Send shares to");
+    expect(receiverField.value).toBe("vitalik.eth");
+    expect(receiverField.fieldType).toBe("address");
+    expect(receiverField.format).toBe("addressName");
+    expect(receiverField.rawAddress).toBe(
+      toChecksumAddress(hexToBytes(RECEIVER)),
+    );
+    expect(receiverField.tokenAddress).toBeUndefined();
+    expect(receiverField.embeddedCalldata).toBeUndefined();
+    expect(receiverField.warning).toBeUndefined();
+
+    // Metadata — owner and info inherited from common-KilnVaults.json
+    assert(result.metadata);
+    expect(result.metadata.owner).toBe("Kiln");
+    expect(result.metadata.contractName).toBeUndefined();
+    expect(result.metadata.info).toEqual({ url: "https://kiln.fi/" });
+
+    expect(result.interpolatedIntent).toBeUndefined();
+    expect(result.rawCalldataFallback).toBeUndefined();
+    expect(result.warnings).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Make `resolveWithIncludes` follow nested `includes` chains; previously only the immediate include was merged, so formats defined in a deeper file (e.g. an `ercs/` ERC-standard descriptor) were silently dropped and the selector surfaced as `NO_FORMAT_MATCH`.
- Add a `CYCLIC_INCLUDES` warning for self-referencing chains (returned via the resolver's `{ warning }` envelope rather than throwing).
- Tighten the resolver contract: it now always returns `{ descriptor } | { warning }` and emits `NO_DESCRIPTOR` itself, so `format()` / `formatTypedData()` no longer special-case `undefined`. Any resolver warning in `format()` is paired with `rawCalldataFallback` when the calldata parses.
- Add a Kiln Vault USDT Aave v3 registry test case exercising the full chain: `calldata-Vault-USDT-Aave-v3.json` → `common-KilnVaults.json` → `ercs/calldata-erc4626-vaults.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)