### PR TITLE
Preserve precision in duration formatting

### DIFF
--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -634,14 +634,14 @@ export function formatDuration(value: ArgumentValue): RenderFieldResult {
   if (value.type !== "uint" && value.type !== "int")
     return typeMismatch(value, "uint or int", "duration");
 
-  const totalSeconds = Number(value.value < 0n ? -value.value : value.value);
-  const hours = Math.floor(totalSeconds / 3600);
-  const minutes = Math.floor((totalSeconds % 3600) / 60);
-  const secs = totalSeconds % 60;
+  const totalSeconds = value.value < 0n ? -value.value : value.value;
+  const hours = totalSeconds / 3600n;
+  const minutes = (totalSeconds % 3600n) / 60n;
+  const secs = totalSeconds % 60n;
 
-  const hh = String(hours).padStart(2, "0");
-  const mm = String(minutes).padStart(2, "0");
-  const ss = String(secs).padStart(2, "0");
+  const hh = hours.toString().padStart(2, "0");
+  const mm = minutes.toString().padStart(2, "0");
+  const ss = secs.toString().padStart(2, "0");
 
   return { rendered: `${hh}:${mm}:${ss}` };
 }

--- a/test/formatters.spec.ts
+++ b/test/formatters.spec.ts
@@ -1181,6 +1181,11 @@ describe("formatDuration", () => {
     expect(result.rendered).toBe("100:00:00");
   });
 
+  it("formats values above Number.MAX_SAFE_INTEGER without precision loss", () => {
+    const result = formatDuration(uint(9007199254740993n));
+    expect(result.rendered).toBe("2501999792983:36:33");
+  });
+
   it("accepts int type", () => {
     const result = formatDuration(int(8250n));
     expect(result.rendered).toBe("02:17:30");


### PR DESCRIPTION
Fixes duration formatting for large integer values.

`formatDuration` converted bigint seconds through `Number(...)`, so values above `Number.MAX_SAFE_INTEGER` could lose precision before splitting into hours/minutes/seconds. This keeps the calculation in bigint until rendering.