### PR TITLE
fix(interpolation): resolve placeholders against #.-prefixed paths

### DIFF
--- a/src/calldata.ts
+++ b/src/calldata.ts
@@ -18,6 +18,7 @@ import {
   isCalldataDescriptorBoundTo,
   resolveMetadataValue,
   resolveTransactionPath,
+  stripStructuredRootPrefix,
   toArgumentValue,
 } from "./descriptor.js";
 import {
@@ -92,15 +93,19 @@ export async function formatCalldata(
     if (path.startsWith("@.")) return resolveTransactionPath(path, tx);
     if (path.startsWith("$."))
       return toArgumentValue(resolveMetadataValue(descriptor.metadata, path));
-    const stripped = path.startsWith("#.") ? path.slice(2) : path;
-    const key = normalizeNegativeIndices(stripped, decoded.arrayLengths);
+    const key = normalizeNegativeIndices(
+      stripStructuredRootPrefix(path),
+      decoded.arrayLengths,
+    );
     if (key === undefined) return undefined;
     return decoded.values.get(key);
   };
 
   const getArrayLength = (path: string): number => {
-    const stripped = path.startsWith("#.") ? path.slice(2) : path;
-    const key = normalizeNegativeIndices(stripped, decoded.arrayLengths);
+    const key = normalizeNegativeIndices(
+      stripStructuredRootPrefix(path),
+      decoded.arrayLengths,
+    );
     if (key === undefined) return 0;
     return decoded.arrayLengths.get(key) ?? 0;
   };

--- a/src/descriptor.ts
+++ b/src/descriptor.ts
@@ -272,6 +272,10 @@ export function fieldTypeForFormat(
   }
 }
 
+export function stripStructuredRootPrefix(path: string): string {
+  return path.startsWith("#.") ? path.slice(2) : path;
+}
+
 /**
  * Resolves an ERC-7730 path to an ArgumentValue.
  * Handles `@.` (container), `$.` (metadata), `#.` (structured data), and bare paths.
@@ -490,7 +494,7 @@ export function interpolateTemplate(
       if (key.length === 0) {
         throw new Error("Empty placeholder in interpolated intent");
       }
-      const value = values.get(key);
+      const value = values.get(stripStructuredRootPrefix(key));
       if (value === undefined) {
         throw new Error(`Missing interpolated value for '${key}'`);
       }

--- a/src/eip712.ts
+++ b/src/eip712.ts
@@ -19,6 +19,7 @@ import {
   isEip712DescriptorBoundTo,
   resolveMetadataValue,
   resolveTypedDataPath,
+  stripStructuredRootPrefix,
 } from "./descriptor.js";
 import { warn } from "./utils.js";
 import { applyFieldFormats } from "./fields.js";
@@ -63,15 +64,19 @@ export async function formatEip712(
     if (path.startsWith("@.")) return resolveTypedDataPath(path, typedData);
     if (path.startsWith("$."))
       return toArgumentValue(resolveMetadataValue(descriptor.metadata, path));
-    const key = path.startsWith("#.") ? path.slice(2) : path;
-    const raw = getMessageValue(typedData.message, key);
+    const raw = getMessageValue(
+      typedData.message,
+      stripStructuredRootPrefix(path),
+    );
     if (raw === undefined) return undefined;
     return toArgumentValue(raw);
   };
 
   const getArrayLength = (path: string): number => {
-    const key = path.startsWith("#.") ? path.slice(2) : path;
-    const raw = getMessageValue(typedData.message, key);
+    const raw = getMessageValue(
+      typedData.message,
+      stripStructuredRootPrefix(path),
+    );
     return Array.isArray(raw) ? raw.length : 0;
   };
 

--- a/src/fields.ts
+++ b/src/fields.ts
@@ -33,6 +33,7 @@ import {
   mergeDefinitions,
   resolveFieldValue,
   resolvedToAddress,
+  stripStructuredRootPrefix,
   toArgumentValue,
 } from "./descriptor.js";
 import {
@@ -264,7 +265,9 @@ async function processSingleField(
     ...(embeddedCalldata && { embeddedCalldata }),
   };
 
-  if (merged.path) ctx.renderedValues.set(merged.path, finalValue);
+  if (merged.path) {
+    ctx.renderedValues.set(stripStructuredRootPrefix(merged.path), finalValue);
+  }
   return { field: displayField };
 }
 
@@ -565,14 +568,15 @@ function joinArrayValues(
   renderedValues: Map<string, string>,
 ): void {
   for (const { path, length } of arrayLengths) {
+    const basePath = stripStructuredRootPrefix(path);
     const parts: string[] = [];
     for (let i = 0; i < length; i++) {
-      const v = renderedValues.get(`${path}.[${i}]`);
+      const v = renderedValues.get(`${basePath}.[${i}]`);
       if (v !== undefined) parts.push(v);
     }
     if (parts.length > 0) {
-      renderedValues.set(`${path}.[]`, parts.join(" and "));
-      renderedValues.set(path, parts.join(" and "));
+      renderedValues.set(`${basePath}.[]`, parts.join(" and "));
+      renderedValues.set(basePath, parts.join(" and "));
     }
   }
 }

--- a/src/fields.ts
+++ b/src/fields.ts
@@ -295,8 +295,7 @@ async function processGroupArrayPath(
       if (path.startsWith("@.") || path.startsWith("$.")) {
         return ctx.resolvePath(path);
       }
-      const key = path.startsWith("#.") ? path.slice(2) : path;
-      return ctx.resolvePath(`${prefix}.${key}`);
+      return ctx.resolvePath(`${prefix}.${stripStructuredRootPrefix(path)}`);
     };
 
     const result = await processFlatFields(group.fields ?? [], {
@@ -419,7 +418,7 @@ async function processStructGroup(
   group: DescriptorFieldGroup,
   ctx: FieldContext,
 ): Promise<{ group: DisplayFieldGroup } | { warnings: Warning[] }> {
-  const prefix = parseGroupBasePath(group.path).replace(/^#\./, "");
+  const prefix = stripStructuredRootPrefix(parseGroupBasePath(group.path));
 
   const scopedCtx: FieldContext = prefix
     ? {
@@ -428,8 +427,9 @@ async function processStructGroup(
           if (path.startsWith("@.") || path.startsWith("$.")) {
             return ctx.resolvePath(path);
           }
-          const key = path.startsWith("#.") ? path.slice(2) : path;
-          return ctx.resolvePath(`${prefix}.${key}`);
+          return ctx.resolvePath(
+            `${prefix}.${stripStructuredRootPrefix(path)}`,
+          );
         },
       }
     : ctx;

--- a/test/fields.spec.ts
+++ b/test/fields.spec.ts
@@ -13,6 +13,7 @@ import {
   parseByteSlice,
 } from "../src/fields.js";
 import type { ArgumentValue, BaseResolvePath } from "../src/descriptor.js";
+import { stripStructuredRootPrefix } from "../src/descriptor.js";
 import type {
   DescriptorFieldFormat,
   DescriptorFieldGroup,
@@ -26,10 +27,7 @@ import { hexToBytes, isFieldGroup } from "../src/utils.js";
 
 /** Build a BaseResolvePath from a simple key→ArgumentValue map. */
 function mapResolvePath(map: Record<string, ArgumentValue>): BaseResolvePath {
-  return (path: string) => {
-    const key = path.startsWith("#.") ? path.slice(2) : path;
-    return map[key];
-  };
+  return (path: string) => map[stripStructuredRootPrefix(path)];
 }
 
 /** Build a getArrayLength from a map of path→length. */

--- a/test/registry-cases/lido/calldata-stETH.json
+++ b/test/registry-cases/lido/calldata-stETH.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "../../specs/erc7730-v2.schema.json",
+  "context": {
+    "$id": "stETH",
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84"
+        }
+      ]
+    }
+  },
+  "metadata": {
+    "owner": "Lido DAO",
+    "info": { "url": "https://lido.fi" },
+    "constants": {
+      "stETHaddress": "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84"
+    },
+    "contractName": "stETH"
+  },
+  "display": {
+    "formats": {
+      "approve(address _spender, uint256 _amount)": {
+        "intent": "Approve stETH",
+        "interpolatedIntent": "Allow to spend {_amount}",
+        "fields": [
+          {
+            "label": "Spender",
+            "format": "addressName",
+            "params": { "types": ["contract"], "sources": ["local"] },
+            "path": "#._spender",
+            "visible": "always"
+          },
+          {
+            "label": "Amount",
+            "format": "tokenAmount",
+            "path": "#._amount",
+            "params": {
+              "token": "$.metadata.constants.stETHaddress",
+              "threshold": "0x8000000000000000000000000000000000000000000000000000000000000000",
+              "message": "Unlimited"
+            },
+            "visible": "always"
+          }
+        ]
+      },
+      "submit(address _referral)": {
+        "intent": "Stake ETH",
+        "interpolatedIntent": "Stake {@.value} ETH",
+        "fields": [
+          { "label": "Amount", "format": "amount", "path": "@.value" },
+          { "label": "Referral", "path": "#._referral", "visible": "never" }
+        ]
+      },
+      "transfer(address _recipient, uint256 _amount)": {
+        "intent": "Transfer stETH",
+        "interpolatedIntent": "Send {_amount} to {_recipient}",
+        "fields": [
+          {
+            "label": "Recipient",
+            "format": "addressName",
+            "params": {
+              "types": ["eoa", "wallet"],
+              "sources": ["local", "ens"]
+            },
+            "path": "#._recipient",
+            "visible": "always"
+          },
+          {
+            "label": "Amount",
+            "format": "tokenAmount",
+            "path": "#._amount",
+            "params": { "token": "$.metadata.constants.stETHaddress" },
+            "visible": "always"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/registry-cases/lido/lido.spec.ts
+++ b/test/registry-cases/lido/lido.spec.ts
@@ -1,11 +1,14 @@
 /**
- * Tests for Lido WithdrawalQueueERC721 descriptor:
- * - claimWithdrawals: uint256[] array iteration with a visible-never sibling array
+ * Tests for Lido descriptors:
+ * - WithdrawalQueueERC721.claimWithdrawals: uint256[] array iteration with a
+ *   visible-never sibling array
+ * - stETH.approve: addressName + tokenAmount with descriptor constants
  */
 
 import { describe, it, expect, assert } from "vitest";
 import { format, isFieldGroup } from "../../../src/index.js";
-import type { DisplayModel } from "../../../src/types.js";
+import type { DisplayModel, ExternalDataProvider } from "../../../src/types.js";
+import { hexToBytes, toChecksumAddress } from "../../../src/utils.js";
 import { buildEmbeddedResolverOpts } from "../../utils.js";
 
 describe("Lido WithdrawalQueueERC721", () => {
@@ -83,6 +86,114 @@ describe("Lido WithdrawalQueueERC721", () => {
       expect(result.metadata.info).toEqual({ url: "https://lido.fi" });
 
       expect(result.interpolatedIntent).toBeUndefined();
+      expect(result.rawCalldataFallback).toBeUndefined();
+      expect(result.warnings).toBeUndefined();
+    });
+  });
+});
+
+describe("Lido stETH", () => {
+  const CHAIN_ID = 1;
+  const CONTRACT = "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84";
+  const SPENDER = "0x889edC2eDab5f40e902b864aD4d7AdE8E412F9B1";
+
+  const resolveLocalName: ExternalDataProvider["resolveLocalName"] = async (
+    address,
+  ) => {
+    if (address === SPENDER.toLowerCase()) {
+      return { name: "WithdrawalQueueERC721", typeMatch: true };
+    }
+    return null;
+  };
+
+  const resolveToken: ExternalDataProvider["resolveToken"] = async (
+    chainId,
+    tokenAddress,
+  ) => {
+    if (chainId === CHAIN_ID && tokenAddress === CONTRACT.toLowerCase()) {
+      return { name: "Liquid staked Ether 2.0", symbol: "stETH", decimals: 18 };
+    }
+    return null;
+  };
+
+  function buildOpts(externalDataProvider?: ExternalDataProvider) {
+    return buildEmbeddedResolverOpts(
+      __dirname,
+      {
+        calldataDescriptorFiles: [
+          {
+            chainId: CHAIN_ID,
+            address: CONTRACT,
+            file: "calldata-stETH.json",
+          },
+        ],
+      },
+      externalDataProvider,
+    );
+  }
+
+  // =========================================================================
+  // approve
+  // =========================================================================
+  describe("approve", () => {
+    // approve(address _spender, uint256 _amount)
+    //   selector:  0x095ea7b3
+    //   _spender:  0x889edC2eDab5f40e902b864ad4d7ade8e412f9b1 (WithdrawalQueueERC721)
+    //   _amount:   2_000_000_000_000_000_000 (2 stETH, below the 2^255 "unlimited" threshold)
+    const APPROVE_CALLDATA =
+      "0x095ea7b3" +
+      "000000000000000000000000889edc2edab5f40e902b864ad4d7ade8e412f9b1" +
+      "0000000000000000000000000000000000000000000000001bc16d674ec80000";
+
+    it("formats an approve call resolving the spender name and stETH amount", async () => {
+      const opts = buildOpts({ resolveLocalName, resolveToken });
+
+      const result: DisplayModel = await format(
+        {
+          chainId: CHAIN_ID,
+          to: CONTRACT,
+          data: APPROVE_CALLDATA,
+        },
+        opts,
+      );
+
+      expect(result.intent).toBe("Approve stETH");
+      expect(result.interpolatedIntent).toBe("Allow to spend 2 stETH");
+
+      assert(result.fields);
+      expect(result.fields).toHaveLength(2);
+
+      const spenderField = result.fields[0];
+      assert(!isFieldGroup(spenderField));
+      expect(spenderField.label).toBe("Spender");
+      expect(spenderField.value).toBe("WithdrawalQueueERC721");
+      expect(spenderField.fieldType).toBe("address");
+      expect(spenderField.format).toBe("addressName");
+      expect(spenderField.rawAddress).toBe(
+        toChecksumAddress(hexToBytes(SPENDER)),
+      );
+      expect(spenderField.tokenAddress).toBeUndefined();
+      expect(spenderField.embeddedCalldata).toBeUndefined();
+      expect(spenderField.warning).toBeUndefined();
+
+      const amountField = result.fields[1];
+      assert(!isFieldGroup(amountField));
+      expect(amountField.label).toBe("Amount");
+      expect(amountField.value).toBe("2 stETH");
+      expect(amountField.fieldType).toBe("uint");
+      expect(amountField.format).toBe("tokenAmount");
+      expect(amountField.tokenAddress).toBe(
+        toChecksumAddress(hexToBytes(CONTRACT)),
+      );
+      expect(amountField.rawAddress).toBeUndefined();
+      expect(amountField.embeddedCalldata).toBeUndefined();
+      expect(amountField.warning).toBeUndefined();
+
+      assert(result.metadata);
+      expect(result.metadata.owner).toBe("Lido DAO");
+      expect(result.metadata.contractName).toBe("stETH");
+      expect(result.metadata.info).toEqual({ url: "https://lido.fi" });
+
       expect(result.rawCalldataFallback).toBeUndefined();
       expect(result.warnings).toBeUndefined();
     });


### PR DESCRIPTION
## Summary

- `renderedValues` keyed entries verbatim by their descriptor path, so a field declared with `path: "#._amount"` could not be referenced from a template like `Allow to spend {_amount}` — the lookup missed and the intent fell back to `undefined` with an `INTERPOLATION_ERROR` warning. The Lido stETH and WithdrawalQueueERC721 registry descriptors both hit this.
- Added `stripStructuredRootPrefix()` in [`descriptor.ts`](src/descriptor.ts) and apply it both when storing entries in `renderedValues` (single fields + array joins) and when looking up a placeholder key in `interpolateTemplate`, so `{name}` and `{#.name}` are equivalent — matching the ERC-7730 spec, where `#.foo` and `foo` refer to the same value.
- Added a Lido `stETH.approve` registry test case that exercises the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)