### PR TITLE
ci: exclude release PRs from auto-generated changelog

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    labels:
+      - release

--- a/.github/workflows/label-release-pr.yml
+++ b/.github/workflows/label-release-pr.yml
@@ -1,0 +1,18 @@
+name: Label release PRs
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  label:
+    if: github.head_ref == 'release'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - run: gh pr edit "$PR" --add-label release --repo "$REPO"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/label-release-pr.yml` that auto-labels PRs from the `release` branch with the `release` label.
- Adds `.github/release.yml` configuring `gh release create --generate-notes` to exclude PRs with the `release` label.
- The `release` label has already been created in the repo.

Together these prevent the previous release's version-bump PR from showing up in the next release's auto-generated changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)