### PR TITLE
Split filesystem resolver into a Node-only subpath export

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,7 +122,12 @@ wraps it with `buildSliceResolvePath` to handle byte slice paths (e.g. `srcToken
 
 ## Descriptor Sources
 
-The resolver accepts `GitHubResolverOptions` or `EmbeddedResolverOptions` to control where descriptors come from.
+`FormatOptions.descriptorResolverOptions` is a discriminated union:
+`GitHubResolverOptions` (`type: "github"`) for the built-in registry, or
+`CustomResolverOptions` (`type: "custom"`) that wraps any pre-built
+`DescriptorResolver`. The filesystem resolver (in
+`@ethereum-sourcify/clear-signing/filesystem`) is one such custom resolver,
+shipped from a separate entry point so it stays out of browser bundles.
 
 ### `GitHubResolverOptions`
 
@@ -143,7 +148,7 @@ const opts: FormatOptions = {
 
 **How it works:**
 
-1. The public `resolveCalldataDescriptor` / `resolveTypedDataDescriptor` accept the same `GitHubResolverOptions | EmbeddedResolverOptions` value that `FormatOptions.descriptorResolverOptions` carries. They build an internal `Resolver` (`{ index, fetchDescriptor }`) via the module-private `createResolver`. For the `"github"` case without an explicit `options.index`, `createResolver` calls `fetchPrebuiltRegistryIndex(source)` to fetch `index.calldata.json` and `index.eip712.json` in parallel. **No internal caching** — every resolve call builds a fresh resolver, so callers should pre-fetch the index once and pass the same `descriptorResolverOptions.index` to every `format()` call.
+1. The public `resolveCalldataDescriptor` / `resolveTypedDataDescriptor` accept the same `GitHubResolverOptions | CustomResolverOptions` value that `FormatOptions.descriptorResolverOptions` carries. They build a `DescriptorResolver` (`{ index, fetchDescriptor }`) via the module-private `createResolver`. For `type: "github"` without an explicit `options.index`, `createResolver` calls `fetchPrebuiltRegistryIndex(source)` to fetch `index.calldata.json` and `index.eip712.json` in parallel. For `type: "custom"`, it returns `options.resolver` unchanged. **No internal caching** — every resolve call builds a fresh resolver, so callers should pre-fetch the index once and pass the same `descriptorResolverOptions.index` to every `format()` call.
 2. The fetched index has two maps:
    - `calldataIndex: Record<caip10, path>` — keyed by `context.contract.deployments[].{chainId, address}`
    - `typedDataIndex: Record<caip10, Record<primaryType, TypedDataIndexEntry[]>>` — keyed by `context.eip712.deployments[].{chainId, address}`, then by primary type. Each entry carries the descriptor `path` and the keccak256 hashes of every `encodeType` it declares (`display.formats` keys), so multiple descriptors at the same `(chainId, verifyingContract, primaryType)` triple can be disambiguated at lookup time.
@@ -155,19 +160,33 @@ const opts: FormatOptions = {
 
 ERC-7730 defines several ways to identify an EIP-712 descriptor: `deployments` (chain + address array), `domain` (key-value domain match), and `domainSeparator` (pre-computed hash). The index only keys on `context.eip712.deployments`, because the other forms cannot be cheaply pre-indexed without access to a live domain. Descriptors that rely solely on `domain` or `domainSeparator` for binding will not be discoverable through the GitHub index.
 
-### `EmbeddedResolverOptions`
+### `CustomResolverOptions` and the filesystem resolver
 
-Loads descriptors from a local directory using dynamic `import()`. Useful for bundled/offline builds.
+`{ type: "custom", resolver }` plugs any `DescriptorResolver` into the
+format pipeline. The library ships one such resolver out of the box: the
+filesystem resolver, which lives in `src/filesystem.ts` and is exported
+from the `@ethereum-sourcify/clear-signing/filesystem` subpath. It is
+Node-only (uses `node:fs/promises`) and intentionally separated from the
+main entry so consumers that never touch it don't pull a Node builtin into
+their browser bundles.
 
 ```typescript
+import { createFilesystemResolver } from "@ethereum-sourcify/clear-signing/filesystem";
+
 const opts: FormatOptions = {
   descriptorResolverOptions: {
-    type: "embedded",
-    index: myIndex, // RegistryIndex with CAIP-10 → path mappings
-    descriptorDirectory: "./descriptors",
+    type: "custom",
+    resolver: createFilesystemResolver({
+      index: myIndex,
+      descriptorDirectory: "./descriptors",
+    }),
   },
 };
 ```
+
+Any other source (in-memory map, custom HTTP endpoint, ...) is implemented
+by satisfying the `DescriptorResolver` shape directly and wrapping it in
+`{ type: "custom", resolver }`.
 
 ### GitHub client module (`github-registry-client.ts`)
 
@@ -313,7 +332,7 @@ Warnings are returned in the `DisplayModel.warnings` array and on individual `Di
 
 ### Testing with a custom descriptor
 
-Use `GitHubResolverOptions` with a manually built `RegistryIndex` and mock `fetch` in tests:
+Most spec tests use the filesystem resolver via `buildFilesystemResolverOpts` in `test/utils.ts` (descriptors live alongside the test as JSON files). For tests that need to mock the GitHub fetch path, pass `GitHubResolverOptions` with a manually built `RegistryIndex` and mock `fetch`:
 
 ```typescript
 const index: RegistryIndex = {

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -42,7 +42,7 @@ Alternatively, you can fetch at build time and bundle the resulting JSON with yo
 Two advanced options you typically won't need:
 
 - **`createGitHubRegistryIndex(source?)`** — walks the registry tree and builds the index in-process. Significantly slower than `fetchPrebuiltRegistryIndex` (one fetch per descriptor file). Use when the prebuilt indexes are stale, missing entries, or when pointing at a fork that doesn't publish them.
-- **Embedded resolver** (`type: "embedded"`) — load descriptor JSON files from a local directory via dynamic `import()`. Useful for fully bundled/offline builds. See the README for the shape.
+- **Custom resolvers** — anything matching the `DescriptorResolver` shape (in-memory map, custom HTTP endpoint, etc.) can be wrapped in `{ type: "custom", resolver }`. One custom resolver ships in the library: the Node-only filesystem resolver at `@ethereum-sourcify/clear-signing/filesystem`, which loads descriptor JSON files from a local directory. See the README for details.
 
 ## 3. Build the `ExternalDataProvider`
 

--- a/README.md
+++ b/README.md
@@ -150,9 +150,8 @@ interface FormatOptions {
   /**
    * Controls where descriptors are fetched from.
    * Defaults to the GitHub registry when omitted.
-   * Also allows to pass descriptors directly via the `embedded` option.
    */
-  descriptorResolverOptions?: GitHubResolverOptions | EmbeddedResolverOptions;
+  descriptorResolverOptions?: GitHubResolverOptions | CustomResolverOptions;
 }
 ```
 
@@ -234,12 +233,13 @@ const opts = {
 
 If the prebuilt indexes are missing descriptors or you're using a fork that doesn't publish them, walk the registry yourself with `createGitHubRegistryIndex()`. It's significantly slower (one fetch per descriptor file vs. two for the prebuilt indexes) so reserve it for setup-time use.
 
-#### Embedded Descriptors
+#### Filesystem resolver (Node-only)
 
-For bundled descriptors or testing, build your own index and descriptors will be loaded via JS module resolution:
+For bundled descriptors or testing in Node, build your own index and load descriptor JSON files from a local directory. The filesystem resolver lives in a Node-only subpath export so it stays out of browser bundles:
 
 ```typescript
 import { format } from "@ethereum-sourcify/clear-signing";
+import { createFilesystemResolver } from "@ethereum-sourcify/clear-signing/filesystem";
 import type { RegistryIndex } from "@ethereum-sourcify/clear-signing";
 
 const index: RegistryIndex = {
@@ -252,10 +252,31 @@ const index: RegistryIndex = {
 
 const result = await format(tx, {
   descriptorResolverOptions: {
-    type: "embedded",
-    index,
-    descriptorDirectory: "./descriptors",
+    type: "custom",
+    resolver: createFilesystemResolver({
+      index,
+      descriptorDirectory: "./descriptors",
+    }),
   },
+});
+```
+
+#### Custom resolvers
+
+`{ type: "custom", resolver }` accepts any object matching the `DescriptorResolver` shape, so you can plug in arbitrary descriptor sources (in-memory map, custom HTTP endpoint, ...):
+
+```typescript
+import type { DescriptorResolver } from "@ethereum-sourcify/clear-signing";
+
+const resolver: DescriptorResolver = {
+  index,
+  fetchDescriptor: async (path) => {
+    /* return parsed descriptor for `path` */
+  },
+};
+
+const result = await format(tx, {
+  descriptorResolverOptions: { type: "custom", resolver },
 });
 ```
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,16 @@
         "default": "./dist/index.cjs"
       }
     },
+    "./filesystem": {
+      "import": {
+        "types": "./dist/filesystem.d.ts",
+        "default": "./dist/filesystem.js"
+      },
+      "require": {
+        "types": "./dist/filesystem.d.cts",
+        "default": "./dist/filesystem.cjs"
+      }
+    },
     "./package.json": "./package.json"
   },
   "repository": {

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -1,0 +1,63 @@
+/// <reference types="node" />
+
+/**
+ * Node-only entry point for loading ERC-7730 descriptors from a local
+ * filesystem directory of JSON files.
+ *
+ * @example
+ * ```typescript
+ * import { format } from "@ethereum-sourcify/clear-signing";
+ * import { createFilesystemResolver } from "@ethereum-sourcify/clear-signing/filesystem";
+ *
+ * const resolver = createFilesystemResolver({
+ *   index,
+ *   descriptorDirectory: "./descriptors",
+ * });
+ *
+ * const result = await format(tx, { descriptorResolverOptions: resolver });
+ * ```
+ *
+ * Lives in a separate entry point so the main bundle stays isomorphic —
+ * consumers that only use the GitHub resolver never pull `node:fs/promises`
+ * into their browser bundle.
+ */
+
+import { readFile } from "node:fs/promises";
+import type { Descriptor, DescriptorResolver, RegistryIndex } from "./types.js";
+
+export type { DescriptorResolver };
+
+/**
+ * Input to {@link createFilesystemResolver}. Describes a directory of
+ * descriptor JSON files plus the matching {@link RegistryIndex}.
+ */
+export type FilesystemResolverOptions = {
+  index: RegistryIndex;
+  /**
+   * Filesystem root that descriptor paths in `index` are resolved against.
+   * The filesystem resolver reads `${descriptorDirectory}/${path}` from disk.
+   * If a descriptor's `includes` chain reaches outside its own directory
+   * (e.g. `../../ercs/shared.json`), the index entries must be stored with
+   * enough leading directory segments to absorb the `..` traversal — see
+   * the contract on {@link RegistryIndex.calldataIndex}.
+   */
+  descriptorDirectory: string;
+};
+
+/**
+ * Build a {@link DescriptorResolver} that reads descriptor JSON files from a
+ * local filesystem directory. The returned resolver is passed to
+ * `FormatOptions.descriptorResolverOptions`.
+ */
+export function createFilesystemResolver(
+  options: FilesystemResolverOptions,
+): DescriptorResolver {
+  return {
+    index: options.index,
+    fetchDescriptor: async (path) => {
+      const filePath = `${options.descriptorDirectory}/${path}`;
+      const content = await readFile(filePath, "utf-8");
+      return JSON.parse(content) as Descriptor;
+    },
+  };
+}

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -6,11 +6,11 @@ import {
 import { computeEncodeType } from "./eip712.js";
 import { fetchPrebuiltRegistryIndex } from "./github-registry-index.js";
 import type {
+  CustomResolverOptions,
   Descriptor,
-  EmbeddedResolverOptions,
+  DescriptorResolver,
   GitHubResolverOptions,
   GitHubSource,
-  RegistryIndex,
   TypedData,
   Warning,
 } from "./types.js";
@@ -22,31 +22,25 @@ import {
   warn,
 } from "./utils.js";
 
-/**
- * Internal: an index for path lookup plus a closure that fetches and parses
- * a single descriptor file by repo-relative path. Built by
- * {@link createResolver} and consumed by the resolve functions.
- */
-interface Resolver {
-  index: RegistryIndex;
-  fetchDescriptor: (path: string) => Promise<Descriptor>;
-}
-
 type ResolveDescriptorResult =
   | { descriptor: Descriptor }
   | { warning: Warning };
 
 /**
- * Builds a {@link Resolver} for the given source. For `"github"` without an
- * explicit `options.index`, fetches the prebuilt registry index up front
- * (no caching — recreating the resolver triggers another fetch).
+ * Builds a {@link DescriptorResolver} from the supplied options. For
+ * `{ type: "github" }` without an explicit `options.index`, fetches the
+ * prebuilt registry index up front (no caching — recreating the resolver
+ * triggers another fetch). For `{ type: "custom" }`, returns the user-built
+ * resolver unchanged.
  */
 async function createResolver(
-  options: GitHubResolverOptions | EmbeddedResolverOptions = {
+  options: GitHubResolverOptions | CustomResolverOptions = {
     type: "github",
   },
-): Promise<Resolver> {
+): Promise<DescriptorResolver> {
   switch (options.type) {
+    case "custom":
+      return options.resolver;
     case "github": {
       const source: GitHubSource = {
         repo: options.githubSource?.repo ?? DEFAULT_REPO,
@@ -57,17 +51,6 @@ async function createResolver(
         index,
         fetchDescriptor: async (path) =>
           (await fetchRegistryFile(path, source)) as Descriptor,
-      };
-    }
-    case "embedded": {
-      return {
-        index: options.index,
-        fetchDescriptor: async (path) => {
-          const mod = await import(`${options.descriptorDirectory}/${path}`, {
-            with: { type: "json" },
-          });
-          return (mod.default ?? mod) as Descriptor;
-        },
       };
     }
   }
@@ -82,7 +65,7 @@ async function createResolver(
 export async function resolveCalldataDescriptor(
   chainId: number,
   to: string,
-  options?: GitHubResolverOptions | EmbeddedResolverOptions,
+  options?: GitHubResolverOptions | CustomResolverOptions,
 ): Promise<ResolveDescriptorResult> {
   const resolver = await createResolver(options);
   const path =
@@ -102,7 +85,7 @@ export async function resolveCalldataDescriptor(
  */
 export async function resolveTypedDataDescriptor(
   typedData: TypedData,
-  options?: GitHubResolverOptions | EmbeddedResolverOptions,
+  options?: GitHubResolverOptions | CustomResolverOptions,
 ): Promise<ResolveDescriptorResult> {
   const { chainId, verifyingContract } = typedData.domain;
   if (chainId === undefined || !verifyingContract) {
@@ -142,7 +125,7 @@ function noDescriptorWarning(
 }
 
 async function resolveWithIncludes(
-  resolver: Resolver,
+  resolver: DescriptorResolver,
   path: string,
   visited: Set<string> = new Set(),
 ): Promise<ResolveDescriptorResult> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -387,9 +387,14 @@ export interface FormatOptions {
   /**
    * Controls where descriptors are fetched from.
    * Defaults to the GitHub registry when omitted.
-   * Also allows to pass descriptors directly via the `embedded` option.
+   *
+   * Pass `{ type: "github", ... }` ({@link GitHubResolverOptions}) to fetch
+   * from the registry, or `{ type: "custom", resolver }`
+   * ({@link CustomResolverOptions}) to plug in any pre-built
+   * {@link DescriptorResolver} — for instance the Node-only filesystem
+   * resolver from `@ethereum-sourcify/clear-signing/filesystem`.
    */
-  descriptorResolverOptions?: GitHubResolverOptions | EmbeddedResolverOptions;
+  descriptorResolverOptions?: GitHubResolverOptions | CustomResolverOptions;
 
   // TODO: resolvedImplementationAddress for proxy contracts — may be replaced
   // with an ExternalDataProvider method.
@@ -408,19 +413,31 @@ export type GitHubResolverOptions = {
   githubSource?: Partial<GitHubSource>;
 };
 
-export type EmbeddedResolverOptions = {
-  type: "embedded";
-  index: RegistryIndex; // must be provided for embedded resolvers
-  /**
-   * Filesystem root that descriptor paths in `index` are resolved against.
-   * The embedded resolver does `import(${descriptorDirectory}/${path})`.
-   * If a descriptor's `includes` chain reaches outside its own directory
-   * (e.g. `../../ercs/shared.json`), the index entries must be stored with
-   * enough leading directory segments to absorb the `..` traversal — see
-   * the contract on {@link RegistryIndex.calldataIndex}.
-   */
-  descriptorDirectory: string;
+/**
+ * Plugs a user-built {@link DescriptorResolver} into the format pipeline.
+ * Use this for any descriptor source other than the built-in GitHub
+ * registry — filesystem (see `@ethereum-sourcify/clear-signing/filesystem`),
+ * in-memory map, custom HTTP endpoint, etc.
+ */
+export type CustomResolverOptions = {
+  type: "custom";
+  resolver: DescriptorResolver;
 };
+
+/**
+ * A pre-built descriptor resolver: a registry index plus a closure that
+ * fetches and parses a single descriptor file by its index-relative path.
+ *
+ * Wrap an instance in {@link CustomResolverOptions} and pass it to
+ * {@link FormatOptions.descriptorResolverOptions} to override the default
+ * GitHub-backed resolution with any descriptor source. The library resolves
+ * `includes` chains and merges descriptors using only `index` and
+ * `fetchDescriptor`, so any source that satisfies this shape will work.
+ */
+export interface DescriptorResolver {
+  index: RegistryIndex;
+  fetchDescriptor: (path: string) => Promise<Descriptor>;
+}
 
 export interface RegistryIndex {
   /**
@@ -428,7 +445,7 @@ export interface RegistryIndex {
    * file's path.
    *
    * The path is resolved relative to the resolver root — `descriptorDirectory`
-   * for embedded resolvers, the repository root for GitHub resolvers. It MUST
+   * for the filesystem resolver, the repository root for GitHub resolvers. It MUST
    * be the descriptor's full relative path, not just a basename: an
    * `includes` declared inside the descriptor (e.g. `"../../ercs/foo.json"`)
    * is resolved against the directory of *this* path, and any `..` segments

--- a/test/erc7730-test-cases/example-account-execute.spec.ts
+++ b/test/erc7730-test-cases/example-account-execute.spec.ts
@@ -18,7 +18,7 @@ import {
   selectorForSignature,
   toChecksumAddress,
 } from "../../src/utils.js";
-import { buildEmbeddedResolverOpts } from "../utils.js";
+import { buildFilesystemResolverOpts } from "../utils.js";
 
 // Smart account implementation address — a valid 20-byte hex (the original spec
 // file used "0xYourImplementationAddress" as a placeholder; swapped here so that
@@ -108,7 +108,7 @@ const resolveChainInfo: ExternalDataProvider["resolveChainInfo"] = async (
 };
 
 function buildOpts(externalDataProvider?: ExternalDataProvider): FormatOptions {
-  return buildEmbeddedResolverOpts(
+  return buildFilesystemResolverOpts(
     __dirname,
     {
       calldataDescriptorFiles: [

--- a/test/erc7730-test-cases/example-array-iteration.spec.ts
+++ b/test/erc7730-test-cases/example-array-iteration.spec.ts
@@ -13,7 +13,7 @@ import {
   selectorForSignature,
   toChecksumAddress,
 } from "../../src/utils.js";
-import { buildEmbeddedResolverOpts } from "../utils.js";
+import { buildFilesystemResolverOpts } from "../utils.js";
 
 describe("example-array-iteration.json — distribute", () => {
   const CHAIN_ID = 1;
@@ -88,7 +88,7 @@ describe("example-array-iteration.json — distribute", () => {
     "0000000000000000000000000000000000000000000000000000000000000000";
 
   function buildOpts(externalDataProvider?: ExternalDataProvider) {
-    return buildEmbeddedResolverOpts(
+    return buildFilesystemResolverOpts(
       __dirname,
       {
         calldataDescriptorFiles: [
@@ -434,7 +434,7 @@ describe("example-array-iteration.json — batchExecute", () => {
     "0000000000000000000000000000000000000000000000000000000000000000"; // values[0] = 0
 
   function buildOpts(externalDataProvider?: ExternalDataProvider) {
-    return buildEmbeddedResolverOpts(
+    return buildFilesystemResolverOpts(
       __dirname,
       {
         calldataDescriptorFiles: [

--- a/test/erc7730-test-cases/example-eip712.spec.ts
+++ b/test/erc7730-test-cases/example-eip712.spec.ts
@@ -9,7 +9,7 @@ import { formatTypedData, isFieldGroup } from "../../src/index.js";
 import type { ExternalDataProvider, TypedData } from "../../src/types.js";
 import { toChecksumAddress, hexToBytes } from "../../src/utils.js";
 import {
-  buildEmbeddedResolverOpts,
+  buildFilesystemResolverOpts,
   computeEncodeTypeOrThrow,
 } from "../utils.js";
 
@@ -73,7 +73,7 @@ describe("example-eip712.json — PermitSingle", () => {
   };
 
   function buildOpts(externalDataProvider?: ExternalDataProvider) {
-    return buildEmbeddedResolverOpts(
+    return buildFilesystemResolverOpts(
       __dirname,
       {
         eip712DescriptorFiles: [
@@ -191,7 +191,7 @@ describe("example-eip712.json — PermitSingle", () => {
       domain: { ...PERMIT_SINGLE.domain, chainId: 999 },
     };
 
-    const opts = buildEmbeddedResolverOpts(__dirname, {
+    const opts = buildFilesystemResolverOpts(__dirname, {
       eip712DescriptorFiles: [
         {
           chainId: 999,
@@ -290,7 +290,7 @@ describe("example-eip712.json — PermitBatch", () => {
   ];
 
   function buildOpts(externalDataProvider?: ExternalDataProvider) {
-    return buildEmbeddedResolverOpts(
+    return buildFilesystemResolverOpts(
       __dirname,
       {
         eip712DescriptorFiles: [

--- a/test/erc7730-test-cases/example-include.spec.ts
+++ b/test/erc7730-test-cases/example-include.spec.ts
@@ -8,7 +8,7 @@ import { describe, it, expect, assert } from "vitest";
 import { format, isFieldGroup } from "../../src/index.js";
 import type { ExternalDataProvider } from "../../src/types.js";
 import { toChecksumAddress, hexToBytes } from "../../src/utils.js";
-import { buildEmbeddedResolverOpts } from "../utils.js";
+import { buildFilesystemResolverOpts } from "../utils.js";
 
 describe("example-include.json — approve(address spender, uint256 value)", () => {
   const CONTRACT_ADDRESS = "0xdAC17F958D2ee523a2206206994597C13D831ec7";
@@ -52,7 +52,7 @@ describe("example-include.json — approve(address spender, uint256 value)", () 
   };
 
   function buildOpts(externalDataProvider?: ExternalDataProvider) {
-    return buildEmbeddedResolverOpts(
+    return buildFilesystemResolverOpts(
       __dirname,
       {
         calldataDescriptorFiles: [

--- a/test/erc7730-test-cases/example-main.spec.ts
+++ b/test/erc7730-test-cases/example-main.spec.ts
@@ -11,7 +11,7 @@ import type {
   FormatOptions,
 } from "../../src/types.js";
 import { hexToBytes, toChecksumAddress } from "../../src/utils.js";
-import { buildEmbeddedResolverOpts } from "../utils.js";
+import { buildFilesystemResolverOpts } from "../utils.js";
 
 // USDT on mainnet (matches example-main.json deployment)
 const USDT_ADDRESS = "0xdAC17F958D2ee523a2206206994597C13D831ec7";
@@ -54,7 +54,7 @@ const resolveEnsName: ExternalDataProvider["resolveEnsName"] = async (
 };
 
 function buildOpts(externalDataProvider?: ExternalDataProvider): FormatOptions {
-  return buildEmbeddedResolverOpts(
+  return buildFilesystemResolverOpts(
     __dirname,
     {
       calldataDescriptorFiles: [
@@ -158,7 +158,7 @@ describe("example-main.json — transfer(address to, uint256 value)", () => {
   it("returns DEPLOYMENT_MISMATCH when descriptor does not bind to chain+address", async () => {
     // Index resolves the descriptor for chain 999 + USDT address,
     // but the descriptor itself only binds to chains 1, 137, 42161
-    const opts = buildEmbeddedResolverOpts(__dirname, {
+    const opts = buildFilesystemResolverOpts(__dirname, {
       calldataDescriptorFiles: [
         {
           chainId: 999,

--- a/test/erc7730-test-cases/example-userops-eip712.spec.ts
+++ b/test/erc7730-test-cases/example-userops-eip712.spec.ts
@@ -20,7 +20,7 @@ import {
   toChecksumAddress,
 } from "../../src/utils.js";
 import {
-  buildEmbeddedResolverOpts,
+  buildFilesystemResolverOpts,
   computeEncodeTypeOrThrow,
 } from "../utils.js";
 
@@ -176,7 +176,7 @@ const resolveChainInfo: ExternalDataProvider["resolveChainInfo"] = async (
 };
 
 function buildOpts(externalDataProvider?: ExternalDataProvider): FormatOptions {
-  return buildEmbeddedResolverOpts(
+  return buildFilesystemResolverOpts(
     __dirname,
     {
       eip712DescriptorFiles: [

--- a/test/erc7730-test-cases/example-visibility-rules.spec.ts
+++ b/test/erc7730-test-cases/example-visibility-rules.spec.ts
@@ -17,7 +17,7 @@ import {
   selectorForSignature,
   toChecksumAddress,
 } from "../../src/utils.js";
-import { buildEmbeddedResolverOpts } from "../utils.js";
+import { buildFilesystemResolverOpts } from "../utils.js";
 
 const CONTRACT_ADDRESS = "0x00112233445566778899AABBCCDDEEFF00112233";
 const CHAIN_ID = 1;
@@ -94,7 +94,7 @@ const resolveChainInfo: ExternalDataProvider["resolveChainInfo"] = async (
 };
 
 function buildOpts(externalDataProvider?: ExternalDataProvider): FormatOptions {
-  return buildEmbeddedResolverOpts(
+  return buildFilesystemResolverOpts(
     __dirname,
     {
       calldataDescriptorFiles: [

--- a/test/registry-cases/1inch/1inch.spec.ts
+++ b/test/registry-cases/1inch/1inch.spec.ts
@@ -15,7 +15,7 @@ import {
   selectorForSignature,
   toChecksumAddress,
 } from "../../../src/utils.js";
-import { buildEmbeddedResolverOpts } from "../../utils.js";
+import { buildFilesystemResolverOpts } from "../../utils.js";
 
 describe("1inch AggregationRouterV6", () => {
   const CHAIN_ID = 1;
@@ -33,7 +33,7 @@ describe("1inch AggregationRouterV6", () => {
   };
 
   function buildOpts(externalDataProvider?: ExternalDataProvider) {
-    return buildEmbeddedResolverOpts(
+    return buildFilesystemResolverOpts(
       __dirname,
       {
         calldataDescriptorFiles: [
@@ -317,7 +317,7 @@ describe("1inch NativeOrderFactory", () => {
   const USDC = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
 
   function buildOpts(externalDataProvider?: ExternalDataProvider) {
-    return buildEmbeddedResolverOpts(
+    return buildFilesystemResolverOpts(
       __dirname,
       {
         calldataDescriptorFiles: [

--- a/test/registry-cases/aave-lpv2/aave-lpv2.spec.ts
+++ b/test/registry-cases/aave-lpv2/aave-lpv2.spec.ts
@@ -8,7 +8,7 @@ import { describe, it, expect, assert } from "vitest";
 import { format, isFieldGroup } from "../../../src/index.js";
 import type { DisplayModel, ExternalDataProvider } from "../../../src/types.js";
 import { toChecksumAddress, hexToBytes } from "../../../src/utils.js";
-import { buildEmbeddedResolverOpts } from "../../utils.js";
+import { buildFilesystemResolverOpts } from "../../utils.js";
 
 describe("Aave Lending Pool v2", () => {
   const CHAIN_ID = 1;
@@ -17,7 +17,7 @@ describe("Aave Lending Pool v2", () => {
   const USDC = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
 
   function buildOpts(externalDataProvider?: ExternalDataProvider) {
-    return buildEmbeddedResolverOpts(
+    return buildFilesystemResolverOpts(
       __dirname,
       {
         calldataDescriptorFiles: [

--- a/test/registry-cases/figment/figment.spec.ts
+++ b/test/registry-cases/figment/figment.spec.ts
@@ -8,14 +8,14 @@ import { describe, it, expect, assert } from "vitest";
 import { format, isFieldGroup } from "../../../src/index.js";
 import type { DisplayModel } from "../../../src/types.js";
 import { bytesToHex, selectorForSignature } from "../../../src/utils.js";
-import { buildEmbeddedResolverOpts } from "../../utils.js";
+import { buildFilesystemResolverOpts } from "../../utils.js";
 
 describe("Figment ETH Depositor", () => {
   const CHAIN_ID = 1;
   const CONTRACT = "0x8B0d88B8Be3C15D746Feb0B1f18c883c03B6Aa62";
 
   function buildOpts() {
-    return buildEmbeddedResolverOpts(__dirname, {
+    return buildFilesystemResolverOpts(__dirname, {
       calldataDescriptorFiles: [
         {
           chainId: CHAIN_ID,

--- a/test/registry-cases/kiln/kiln.spec.ts
+++ b/test/registry-cases/kiln/kiln.spec.ts
@@ -12,7 +12,7 @@ import { describe, it, expect, assert } from "vitest";
 import { format, isFieldGroup } from "../../../src/index.js";
 import type { ExternalDataProvider } from "../../../src/types.js";
 import { hexToBytes, toChecksumAddress } from "../../../src/utils.js";
-import { buildEmbeddedResolverOpts } from "../../utils.js";
+import { buildFilesystemResolverOpts } from "../../utils.js";
 
 describe("Kiln Vault USDT Aave v3", () => {
   const CHAIN_ID = 1;
@@ -49,7 +49,7 @@ describe("Kiln Vault USDT Aave v3", () => {
   const TEST_ROOT = join(__dirname, "..", "..");
 
   function buildOpts(externalDataProvider?: ExternalDataProvider) {
-    return buildEmbeddedResolverOpts(
+    return buildFilesystemResolverOpts(
       TEST_ROOT,
       {
         calldataDescriptorFiles: [

--- a/test/registry-cases/lido/lido.spec.ts
+++ b/test/registry-cases/lido/lido.spec.ts
@@ -16,14 +16,14 @@ import {
   selectorForSignature,
   toChecksumAddress,
 } from "../../../src/utils.js";
-import { buildEmbeddedResolverOpts } from "../../utils.js";
+import { buildFilesystemResolverOpts } from "../../utils.js";
 
 describe("Lido WithdrawalQueueERC721", () => {
   const CHAIN_ID = 1;
   const CONTRACT = "0x889edC2eDab5f40e902b864aD4d7AdE8E412F9B1";
 
   function buildOpts(externalDataProvider?: ExternalDataProvider) {
-    return buildEmbeddedResolverOpts(
+    return buildFilesystemResolverOpts(
       __dirname,
       {
         calldataDescriptorFiles: [
@@ -331,7 +331,7 @@ describe("Lido stETH", () => {
   };
 
   function buildOpts(externalDataProvider?: ExternalDataProvider) {
-    return buildEmbeddedResolverOpts(
+    return buildFilesystemResolverOpts(
       __dirname,
       {
         calldataDescriptorFiles: [

--- a/test/registry-cases/lifi/lifi.spec.ts
+++ b/test/registry-cases/lifi/lifi.spec.ts
@@ -8,7 +8,7 @@ import { describe, it, expect, assert } from "vitest";
 import { format, isFieldGroup } from "../../../src/index.js";
 import type { DisplayModel, ExternalDataProvider } from "../../../src/types.js";
 import { hexToBytes, toChecksumAddress } from "../../../src/utils.js";
-import { buildEmbeddedResolverOpts } from "../../utils.js";
+import { buildFilesystemResolverOpts } from "../../utils.js";
 
 describe("LI.FI LIFIDiamond", () => {
   const CHAIN_ID = 1;
@@ -43,7 +43,7 @@ describe("LI.FI LIFIDiamond", () => {
   };
 
   function buildOpts(externalDataProvider?: ExternalDataProvider) {
-    return buildEmbeddedResolverOpts(
+    return buildFilesystemResolverOpts(
       __dirname,
       {
         calldataDescriptorFiles: [

--- a/test/registry-cases/paraswap/paraswap.spec.ts
+++ b/test/registry-cases/paraswap/paraswap.spec.ts
@@ -9,7 +9,7 @@ import { describe, it, expect, assert } from "vitest";
 import { format, isFieldGroup } from "../../../src/index.js";
 import type { ExternalDataProvider } from "../../../src/types.js";
 import { toChecksumAddress, hexToBytes } from "../../../src/utils.js";
-import { buildEmbeddedResolverOpts } from "../../utils.js";
+import { buildFilesystemResolverOpts } from "../../utils.js";
 
 describe("Paraswap AugustusSwapper v6.2", () => {
   const CHAIN_ID = 1;
@@ -47,7 +47,7 @@ describe("Paraswap AugustusSwapper v6.2", () => {
   };
 
   function buildOpts(externalDataProvider?: ExternalDataProvider) {
-    return buildEmbeddedResolverOpts(
+    return buildFilesystemResolverOpts(
       __dirname,
       {
         calldataDescriptorFiles: [

--- a/test/registry-cases/rarible/rarible.spec.ts
+++ b/test/registry-cases/rarible/rarible.spec.ts
@@ -11,7 +11,7 @@ import { formatTypedData, isFieldGroup } from "../../../src/index.js";
 import type { ExternalDataProvider, TypedData } from "../../../src/types.js";
 import { hexToBytes, toChecksumAddress } from "../../../src/utils.js";
 import {
-  buildEmbeddedResolverOpts,
+  buildFilesystemResolverOpts,
   computeEncodeTypeOrThrow,
 } from "../../utils.js";
 
@@ -66,7 +66,7 @@ describe("Rarible ERC-721 lazy mint", () => {
   };
 
   function buildOpts(externalDataProvider?: ExternalDataProvider) {
-    return buildEmbeddedResolverOpts(
+    return buildFilesystemResolverOpts(
       __dirname,
       {
         eip712DescriptorFiles: [

--- a/test/registry-cases/yieldxyz/yieldxyz.spec.ts
+++ b/test/registry-cases/yieldxyz/yieldxyz.spec.ts
@@ -15,14 +15,14 @@ import {
   selectorForSignature,
   toChecksumAddress,
 } from "../../../src/utils.js";
-import { buildEmbeddedResolverOpts } from "../../utils.js";
+import { buildFilesystemResolverOpts } from "../../utils.js";
 
 describe("Yield.xyz POL Validator", () => {
   const CHAIN_ID = 1;
   const CONTRACT = "0xb929b89153fc2eed442e81e5a1add4e2fa39028f";
 
   function buildOpts() {
-    return buildEmbeddedResolverOpts(__dirname, {
+    return buildFilesystemResolverOpts(__dirname, {
       calldataDescriptorFiles: [
         {
           chainId: CHAIN_ID,
@@ -110,7 +110,7 @@ describe("Yield.xyz USDe Vault", () => {
   const RECEIVER = "0x2fec9b58d089447d3e5e50578b9f71321713a470";
 
   function buildOpts(externalDataProvider?: ExternalDataProvider) {
-    return buildEmbeddedResolverOpts(
+    return buildFilesystemResolverOpts(
       __dirname,
       {
         calldataDescriptorFiles: [

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,4 +1,5 @@
 import { computeEncodeType, extractPrimaryType } from "../src/eip712.js";
+import { createFilesystemResolver } from "../src/filesystem.js";
 import type {
   ExternalDataProvider,
   FormatOptions,
@@ -38,10 +39,10 @@ type Eip712DescriptorFileEntry = CalldataDescriptorFileEntry & {
 };
 
 /**
- * Build FormatOptions for an embedded descriptor resolver.
+ * Build FormatOptions backed by the filesystem resolver.
  * Useful for spec test cases where descriptor JSON files live alongside the test.
  */
-export function buildEmbeddedResolverOpts(
+export function buildFilesystemResolverOpts(
   descriptorDirectory: string,
   files: {
     calldataDescriptorFiles?: CalldataDescriptorFileEntry[];
@@ -88,9 +89,8 @@ export function buildEmbeddedResolverOpts(
 
   return {
     descriptorResolverOptions: {
-      type: "embedded",
-      index,
-      descriptorDirectory,
+      type: "custom",
+      resolver: createFilesystemResolver({ index, descriptorDirectory }),
     },
     externalDataProvider,
   };

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,17 +1,11 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts"],
+  entry: ["src/index.ts", "src/filesystem.ts"],
   format: ["esm", "cjs"],
   dts: true,
   clean: true,
   sourcemap: true,
   target: "es2022",
   platform: "neutral",
-  esbuildOptions(options) {
-    options.supported = {
-      ...options.supported,
-      "import-attributes": true,
-    };
-  },
 });


### PR DESCRIPTION
## Summary

- Removes the `import(..., { with: { type: "json" } })` from the main entry that was making Next.js webpack create a context module over `dist/` and crash trying to parse `.js` files as JSON (was reported by a user) — Next.js + turborepo stack on `0.1.10`). The import-attribute syntax also broke older SWC minifiers.
- Adds `@ethereum-sourcify/clear-signing/filesystem` — a Node-only subpath export with `createFilesystemResolver({ index, descriptorDirectory })` that uses `node:fs/promises`. Lives outside the main bundle so isomorphic consumers never pull `node:fs/promises` into their browser bundle.
- Reshapes `FormatOptions.descriptorResolverOptions` from `GitHubResolverOptions | EmbeddedResolverOptions` to a `{ type: "github" } | { type: "custom", resolver: DescriptorResolver }` discriminated union. `DescriptorResolver` is the new public contract: `{ index, fetchDescriptor }`.
- GitHub callers are unchanged. Embedded callers migrate from `{ type: "embedded", index, descriptorDirectory }` to `{ type: "custom", resolver: createFilesystemResolver({ index, descriptorDirectory }) }`.
- Verified end-to-end:
  - Library: typecheck, lint, all 259 tests pass.
  - Test runner (`sourcifyeth/clear-signing-test-runner`): 6-line migration, all 26 fixtures pass.
  - Next.js 16.2 + turborepo + npm + webpack: published `0.1.10` reproduces the original failure exactly; this branch builds clean. Turbopack builds were green on both.

## Breaking change

`type: "embedded"` is removed. Existing embedded consumers migrate per the README; see the test-runner PR for a working example. GitHub consumers are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)