### PR TITLE
fix(nftName): render as "{name} #{tokenId}"

### DIFF
--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -513,7 +513,7 @@ export async function formatNftName(
   }
 
   return {
-    rendered: `Collection Name: ${collection.name} - Token ID: ${tokenId.toString()}`,
+    rendered: `${collection.name} #${tokenId.toString()}`,
   };
 }
 

--- a/test/formatters.spec.ts
+++ b/test/formatters.spec.ts
@@ -940,9 +940,7 @@ describe("formatNftName", () => {
       1,
       provider,
     );
-    expect(result.rendered).toBe(
-      "Collection Name: BoredApeYachtClub - Token ID: 1036",
-    );
+    expect(result.rendered).toBe("BoredApeYachtClub #1036");
     expect(result.warning).toBeUndefined();
   });
 
@@ -1021,7 +1019,7 @@ describe("formatNftName", () => {
       1,
       provider,
     );
-    expect(result.rendered).toBe("Collection Name: CoolCats - Token ID: 42");
+    expect(result.rendered).toBe("CoolCats #42");
   });
 });
 


### PR DESCRIPTION
## Summary

- Switch `nftName` format output from `"Collection Name: {name} - Token ID: {tokenId}"` to the more compact `"{name} #{tokenId}"` form.
- Update the two `formatNftName` test assertions to match.

Aligns the library with the rendering expected by the [registry test cases](https://github.com/manuelwedler/clear-signing-erc7730-registry/pull/7) (8 `flyingtulip` cases currently fail on `0.1.10` solely due to this string difference).