### PR TITLE
feat: generate ERC-20/721 descriptors from a trusted token list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,11 +156,6 @@ different semantics (ERC-20 `value` → tokenAmount vs. ERC-721 `tokenId` → nf
 so the calldata alone cannot disambiguate them. Trust is delegated entirely to the
 wallet.
 
-> The bundled ERC-721 `setApprovalForAll` models access rights as an `enum` over a
-> `bool`, but the `enum` format only accepts `uint`/`int` — so that one field renders
-> the raw bool with an `ARGUMENT_TYPE_MISMATCH` warning. Known limitation of the
-> bundled descriptor, faithful to the registry source.
-
 ## Descriptor Sources
 
 `FormatOptions.descriptorResolverOptions` is a discriminated union:
@@ -303,6 +298,7 @@ Not yet implemented: `interoperableAddressName`
 **Spec-compliance notes:**
 
 - All numeric formats (`date`, `tokenAmount`, `amount`, `enum`, `duration`, `nftName`, `chainId`) accept both `uint` and `int` field types.
+- `enum` additionally accepts `bool` values (`"true"`/`"false"`), resolving the label case-insensitively so capitalized keys like `{ "True": ..., "False": ... }` match (e.g. ERC-721 `setApprovalForAll`).
 - `date` format supports `params.encoding` of `"timestamp"` (unix seconds) and `"blockheight"` (resolved via `ExternalDataProvider.resolveBlockTimestamp`). Falls back to raw with `UNKNOWN_ENCODING` warning for missing or unsupported encodings.
 - `tokenAmount` supports optional `chainId`/`chainIdPath` params to override the container chain ID for cross-chain scenarios (same as `tokenTicker`).
 - `tokenAmount` message defaults to `"Unlimited"` when `params.threshold` is set but `params.message` is omitted.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,8 @@ src/
 ├── calldata.ts                 # Calldata path: formatCalldata(), signature parsing, ABI decoding
 ├── eip712.ts                   # EIP-712 path: formatEip712(), encodeType matching, type resolution
 ├── resolver.ts                 # Descriptor lookup, includes resolution, and descriptor merging
+├── bundled-descriptors.ts      # Bundled ERC-20/721 templates → buildBundledTokenDescriptor()
+├── bundled/                    # The bundled template descriptors as TS consts (erc20.ts, erc721.ts)
 ├── github-registry-client.ts   # I/O layer: GitHub raw/API URL construction and fetch helpers
 └── github-registry-index.ts    # In-memory index built from the GitHub registry file tree
 ```
@@ -72,6 +74,14 @@ src/
   `extractPrimaryType` for `resolver.ts` and `github-registry-index.ts`; the
   rest is module-private.
 
+- **`bundled-descriptors.ts`** — Bundled ERC-20 / ERC-721 template descriptors (the
+  registry's `calldata-erc20-tokens` / `calldata-erc721-nfts` files, transcribed as TS
+  `const`s in `bundled/erc20.ts` and `bundled/erc721.ts`). Exports
+  `buildBundledTokenDescriptor(standard, chainId, address)`, which clones the template and
+  injects `context.contract.deployments` so the result passes the deployment-binding check.
+  Used by `resolveCalldataDescriptor` for the trusted-token fallback. The descriptors are
+  committed as TS rather than imported JSON — see the gotcha below.
+
 ## Key Data Flow
 
 1. **Transaction formatting:**
@@ -81,6 +91,9 @@ src/
    → resolveCalldataDescriptor(tx.chainId, tx.to, opts?.descriptorResolverOptions)
        → createResolver(options) — for "github" without an explicit index,
          calls fetchPrebuiltRegistryIndex() up front
+       → registry index lookup by (chainId, to); on a miss, if
+         options.trustedTokens tags the contract, return
+         buildBundledTokenDescriptor(standard, chainId, to)
    → calldata.formatCalldata(tx, descriptor, externalDataProvider?)
        → findFormatBySelector() matches selector to a display.formats entry
        → decodeArguments() decodes calldata into { values, arrayLengths } maps
@@ -119,6 +132,34 @@ Both calldata and EIP-712 paths share the same field processing pipeline in `fie
 Each builds a `BaseResolvePath` closure that handles `@.`, `$.`, `#.`, and bare path resolution
 for its domain (calldata args vs. EIP-712 message fields). `applyFieldFormats()` internally
 wraps it with `buildSliceResolvePath` to handle byte slice paths (e.g. `srcToken.[-20:]`).
+
+## Trusted Token Descriptors (bundled ERC-20 / ERC-721)
+
+`descriptorResolverOptions.trustedTokens` (type `TrustedTokens`, declared on the
+shared `BaseResolverOptions`, so both the GitHub and custom variants carry it) is
+an optional wallet-provided **data list** keyed `chainId → tokenAddress → standard`
+(`"erc20" | "erc721"`; address keys may be lowercase or EIP-55 checksummed —
+`lookupTrustedToken` tries both). It is the **fallback after
+registry resolution**: `resolveCalldataDescriptor` first looks up the registry
+index by `(chainId, to)`; when the index has a path, its resolution result is
+returned as-is (the descriptor wins even if none of its `display.formats` match
+the calldata — in which case `formatCalldata` later reports `NO_FORMAT_MATCH` —
+and an `includes` failure surfaces its own warning). Only when the index has no
+path does the resolver consult `options.trustedTokens[chainId][to]`; if a
+standard is listed, `buildBundledTokenDescriptor` (in `bundled-descriptors.ts`)
+produces a deployment-bound ERC-20 / ERC-721 template descriptor. The resolver
+never parses the calldata.
+
+**The wallet must tag each token's standard** — the ERC-20 and ERC-721
+`approve` / `transferFrom` functions share identical 4-byte selectors with
+different semantics (ERC-20 `value` → tokenAmount vs. ERC-721 `tokenId` → nftName),
+so the calldata alone cannot disambiguate them. Trust is delegated entirely to the
+wallet.
+
+> The bundled ERC-721 `setApprovalForAll` models access rights as an `enum` over a
+> `bool`, but the `enum` format only accepts `uint`/`int` — so that one field renders
+> the raw bool with an `ARGUMENT_TYPE_MISMATCH` warning. Known limitation of the
+> bundled descriptor, faithful to the registry source.
 
 ## Descriptor Sources
 
@@ -374,6 +415,7 @@ Tests live in `test/`. Current test files:
 - `test/erc7730-test-cases/example-array-iteration.spec.ts` — bundled/sequential array iteration tests
 - `test/registry-cases/1inch/1inch.spec.ts` — 1inch AggregationRouterV6: swap + clipperSwap (byte slice paths)
 - `test/registry-cases/paraswap/paraswap.spec.ts` — Paraswap AugustusSwapper v6.2: RFQ batch fill (tuple array decoding) + BalancerV2 (dynamic bytes + byte range slices)
+- `test/bundled/trusted-tokens.spec.ts` — bundled ERC-20/721 descriptors via `trustedTokens`: standard tagging, selector collision, registry precedence
 
 ### Test guidelines
 
@@ -470,7 +512,7 @@ const display = formatAmountWithDecimals(1000000n, 6); // "1"
 
 ## Gotchas
 
-1. **JSON imports require assertion:** `import data from './file.json' with { type: 'json' };`
+1. **JSON imports require assertion:** `import data from './file.json' with { type: 'json' };` — and for that reason the bundled descriptors (`src/bundled/*.ts`) are committed as TypeScript `const`s, **not** imported JSON. Import attributes caused build/tooling trouble; plain TS bundles as code in every target (ESM/CJS/RN/browser) with no `resolveJsonModule`, no esbuild JSON loader, and no import-attribute support required, and gives the objects compile-time `Descriptor` typing.
 2. **All imports need `.js` extension** (ESM requirement)
 3. **Selector matching is case-sensitive** on function names
 4. **Address normalization:** Always lowercase for comparisons

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -44,7 +44,30 @@ Two advanced options you typically won't need:
 - **`createGitHubRegistryIndex(source?)`** — walks the registry tree and builds the index in-process. Significantly slower than `fetchPrebuiltRegistryIndex` (one fetch per descriptor file). Use when the prebuilt indexes are stale, missing entries, or when pointing at a fork that doesn't publish them.
 - **Custom resolvers** — anything matching the `DescriptorResolver` shape (in-memory map, custom HTTP endpoint, etc.) can be wrapped in `{ type: "custom", resolver }`. One custom resolver ships in the library: the Node-only filesystem resolver at `@ethereum-sourcify/clear-signing/filesystem`, which loads descriptor JSON files from a local directory. See the README for details.
 
-## 3. Build the `ExternalDataProvider`
+## 3. Build the trusted token list
+
+The registry cannot hold a descriptor for every token. To still render plain
+ERC-20 and ERC-721 interactions, pass a `trustedTokens` list inside
+`descriptorResolverOptions`. It maps `chainId → tokenAddress → standard`. If a
+transaction's contract is listed there, the transaction is rendered from a
+bundled ERC-20 / ERC-721 template. Only include tokens in this object that you
+**trust** to be safe to interact with.
+
+```typescript
+import type { TrustedTokens } from "@ethereum-sourcify/clear-signing";
+
+// Token addresses may be lowercase or EIP-55 checksummed.
+const trustedTokens: TrustedTokens = {
+  1: {
+    "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48": "erc20", // USDC
+    "0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d": "erc721", // BAYC
+  },
+};
+
+const descriptorResolverOptions = { type: "github", index, trustedTokens };
+```
+
+## 4. Build the `ExternalDataProvider`
 
 The library is agnostic about how external data is fetched. To resolve token metadata, address names, NFT collections, block timestamps, and chain info, the wallet supplies an `ExternalDataProvider` — an object of async methods backed by the sources the wallet already has (RPC, token list, address book, …).
 
@@ -119,17 +142,21 @@ const externalDataProvider: ExternalDataProvider = {
   },
 };
 
-// Combine with the resolver options from §2 into the FormatOptions object
+// Combine with the resolver options from §2 and §3 into the FormatOptions object
 // that's passed to every format call.
 const opts: FormatOptions = {
-  descriptorResolverOptions: { type: "github", index }, // from §2
+  descriptorResolverOptions: {
+    type: "github",
+    index, // from §2
+    trustedTokens, // from §3
+  },
   externalDataProvider,
 };
 ```
 
 See [`src/types.ts`](src/types.ts) for the exact result type definitions.
 
-## 4. Call the format functions
+## 5. Call the format functions
 
 Three entry points, all returning `DisplayModel` as the output:
 
@@ -141,7 +168,7 @@ Three entry points, all returning `DisplayModel` as the output:
 
 Call them as soon as you have the request and before rendering the confirmation UI — they are async (descriptor fetch + external data resolution).
 
-All three accept the same `opts` object (built in §3) as their optional second argument — reuse it across every call.
+All three accept the same `opts` object (built in §4) as their optional second argument — reuse it across every call.
 
 ### `format`
 
@@ -197,7 +224,7 @@ const batch: Eip5792Batch = {
 const display: BatchDisplayModel = await formatEip5792Batch(batch, opts);
 ```
 
-## 5. Render the `DisplayModel`
+## 6. Render the `DisplayModel`
 
 The library returns a `DisplayModel`. Display its values to the user as the confirmation screen. The library never throws — failures surface as `warnings`.
 

--- a/README.md
+++ b/README.md
@@ -148,8 +148,9 @@ interface FormatOptions {
   externalDataProvider?: ExternalDataProvider;
 
   /**
-   * Controls where descriptors are fetched from.
-   * Defaults to the GitHub registry when omitted.
+   * Controls where descriptors are fetched from, and optionally carries a
+   * `trustedTokens` list (see below). Defaults to the GitHub registry when
+   * omitted.
    */
   descriptorResolverOptions?: GitHubResolverOptions | CustomResolverOptions;
 }
@@ -279,6 +280,27 @@ const result = await format(tx, {
   descriptorResolverOptions: { type: "custom", resolver },
 });
 ```
+
+### Trusted token lists
+
+The registry cannot hold a descriptor for every token. To still render plain ERC-20 and ERC-721 interactions (`transfer`, `approve`, `transferFrom`, `safeTransferFrom`, `setApprovalForAll`), add a `trustedTokens` list to `descriptorResolverOptions`. It maps `chainId → tokenAddress → standard` (addresses lowercase or EIP-55 checksummed). When **no registry descriptor resolves** for a transaction's contract, the library looks it up there; if listed, the transaction is rendered from a **bundled ERC-20 / ERC-721 template descriptor** instead of falling back to raw calldata. A registry descriptor always takes precedence.
+
+```typescript
+import type { TrustedTokens } from "@ethereum-sourcify/clear-signing";
+
+const trustedTokens: TrustedTokens = {
+  1: {
+    "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48": "erc20", // USDC
+    "0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d": "erc721", // BAYC
+  },
+};
+
+const result = await format(tx, {
+  descriptorResolverOptions: { type: "github", index, trustedTokens },
+});
+```
+
+Trust is delegated entirely to the wallet. The library never decides which contracts are trustworthy.
 
 ### Display Model
 

--- a/src/bundled-descriptors.ts
+++ b/src/bundled-descriptors.ts
@@ -1,0 +1,44 @@
+/**
+ * Bundled ERC-20 / ERC-721 template descriptors and the helper that adapts
+ * them to a concrete deployment.
+ *
+ * Why the descriptors are committed as TypeScript `const`s (in `./bundled/*`)
+ * rather than imported JSON:
+ *   - `import descriptor from "./erc20.json" with { type: "json" }` import
+ *     attributes caused build/tooling trouble in this project.
+ *   - Plain TS bundles as code in every target (ESM, CJS, React Native,
+ *     browser) with no `resolveJsonModule`, no esbuild JSON loader, and no
+ *     import-attribute support required.
+ *   - The objects get compile-time `Descriptor` typing for free.
+ */
+
+import type { Descriptor, TokenStandard } from "./types.js";
+import { erc20Descriptor } from "./bundled/erc20.js";
+import { erc721Descriptor } from "./bundled/erc721.js";
+
+const templates: Record<TokenStandard, Descriptor> = {
+  erc20: erc20Descriptor,
+  erc721: erc721Descriptor,
+};
+
+/**
+ * Builds a deployment-bound descriptor for a trusted token by cloning the
+ * bundled template for `standard` and injecting
+ * `context.contract.deployments = [{ chainId, address }]`, so the resulting
+ * descriptor passes the library's deployment-binding check.
+ */
+export function buildBundledTokenDescriptor(
+  standard: TokenStandard,
+  chainId: number,
+  address: string,
+): Descriptor {
+  const descriptor = structuredClone(templates[standard]);
+  descriptor.context = {
+    ...descriptor.context,
+    contract: {
+      ...descriptor.context?.contract,
+      deployments: [{ chainId, address }],
+    },
+  };
+  return descriptor;
+}

--- a/src/bundled/erc20.ts
+++ b/src/bundled/erc20.ts
@@ -1,0 +1,61 @@
+import type { Descriptor } from "../types.js";
+
+/**
+ * Bundled ERC-20 token descriptor.
+ *
+ * Transcribed verbatim from the Ethereum clear-signing registry
+ * (`ercs/calldata-erc20-tokens.json`). Committed as a TypeScript `const`
+ * rather than imported JSON — see the rationale in `bundled-descriptors.ts`.
+ *
+ * The template carries no `context.contract.deployments`; the deployment is
+ * injected per-transaction by `buildBundledTokenDescriptor`.
+ */
+export const erc20Descriptor: Descriptor = {
+  context: { contract: {} },
+  display: {
+    formats: {
+      "transfer(address _to, uint256 _value)": {
+        intent: "Send",
+        fields: [
+          {
+            path: "_value",
+            label: "Amount",
+            format: "tokenAmount",
+            params: { tokenPath: "@.to" },
+            visible: "always",
+          },
+          {
+            path: "_to",
+            label: "To",
+            format: "addressName",
+            params: { types: ["eoa"], sources: ["local", "ens"] },
+            visible: "always",
+          },
+        ],
+      },
+      "approve(address _spender, uint256 _value)": {
+        intent: "Approve",
+        fields: [
+          {
+            path: "_spender",
+            label: "Spender",
+            format: "addressName",
+            params: { types: ["eoa", "contract"] },
+            visible: "always",
+          },
+          {
+            path: "_value",
+            label: "Amount",
+            format: "tokenAmount",
+            params: {
+              tokenPath: "@.to",
+              threshold:
+                "0x8000000000000000000000000000000000000000000000000000000000000000",
+            },
+            visible: "always",
+          },
+        ],
+      },
+    },
+  },
+} as const;

--- a/src/bundled/erc721.ts
+++ b/src/bundled/erc721.ts
@@ -1,0 +1,92 @@
+import type { Descriptor } from "../types.js";
+
+/**
+ * Bundled ERC-721 NFT descriptor.
+ *
+ * Transcribed verbatim from the Ethereum clear-signing registry
+ * (`ercs/calldata-erc721-nfts.json`). Committed as a TypeScript `const`
+ * rather than imported JSON — see the rationale in `bundled-descriptors.ts`.
+ *
+ * The template carries no `context.contract.deployments`; the deployment is
+ * injected per-transaction by `buildBundledTokenDescriptor`.
+ */
+export const erc721Descriptor: Descriptor = {
+  context: { contract: {} },
+  metadata: { enums: { rights: { True: "Grant all", False: "Deny all" } } },
+  display: {
+    definitions: {
+      from: {
+        label: "From",
+        format: "addressName",
+        params: { types: ["eoa"], sources: ["local", "ens"] },
+      },
+      to: {
+        label: "To",
+        format: "addressName",
+        params: { types: ["eoa"], sources: ["local", "ens"] },
+      },
+      operator: {
+        label: "Operator",
+        format: "addressName",
+        params: { types: ["contract"], sources: ["local", "ens"] },
+      },
+      tokenId: {
+        label: "NFT",
+        format: "nftName",
+        params: { collectionPath: "@.to" },
+      },
+    },
+    formats: {
+      "transferFrom(address _from, address _to, uint256 _tokenId)": {
+        intent: "Send NFT",
+        fields: [
+          { path: "_from", $ref: "$.display.definitions.from" },
+          {
+            path: "_to",
+            $ref: "$.display.definitions.to",
+            visible: "always",
+          },
+          {
+            path: "_tokenId",
+            $ref: "$.display.definitions.tokenId",
+            visible: "always",
+          },
+        ],
+      },
+      "safeTransferFrom(address _from, address _to, uint256 _tokenId)": {
+        intent: "Send NFT",
+        fields: [
+          { path: "_from", $ref: "$.display.definitions.from" },
+          { path: "_to", $ref: "$.display.definitions.to" },
+          { path: "_tokenId", $ref: "$.display.definitions.tokenId" },
+        ],
+      },
+      "approve(address _approved, uint256 _tokenId)": {
+        intent: "Approve operator for NFT",
+        fields: [
+          { path: "_approved", $ref: "$.display.definitions.operator" },
+          { path: "_tokenId", $ref: "$.display.definitions.tokenId" },
+        ],
+      },
+      "setApprovalForAll(address _operator, bool _approved)": {
+        $id: "setApprovalForAll",
+        intent: "Manage operator rights for",
+        fields: [
+          {
+            path: "@.to",
+            label: "Collection",
+            format: "addressName",
+            params: { types: ["collection"], sources: ["local", "ens"] },
+          },
+          { path: "_operator", $ref: "$.display.definitions.operator" },
+          {
+            path: "_approved",
+            label: "Access rights",
+            format: "enum",
+            params: { $ref: "$.metadata.enums.rights" },
+          },
+        ],
+      },
+    },
+  },
+} as const;

--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -731,8 +731,8 @@ export function formatEnum(
   value: ArgumentValue,
   metadata: DescriptorMetadata | undefined,
 ): RenderFieldResult {
-  if (value.type !== "uint" && value.type !== "int")
-    return typeMismatch(value, "uint or int", "enum");
+  if (value.type !== "uint" && value.type !== "int" && value.type !== "bool")
+    return typeMismatch(value, "uint, int or bool", "enum");
   const label = resolveEnumLabel(field, value.value.toString(), metadata);
   if (!label) {
     return {
@@ -749,6 +749,10 @@ export function formatEnum(
 /**
  * Resolve an enum label from a metadata map using a string key.
  * Returns undefined when the reference or map can't be resolved.
+ *
+ * The exact key is tried first, then a case-insensitive match — so a `bool`
+ * value (`"true"`/`"false"`) resolves against capitalized keys like
+ * `{ "True": ..., "False": ... }`.
  */
 export function resolveEnumLabel(
   field: FieldFormatOptions,
@@ -762,7 +766,17 @@ export function resolveEnumLabel(
   const enumMap = resolveMetadataValue(metadata, reference);
   if (!enumMap || typeof enumMap !== "object") return undefined;
 
-  const label = (enumMap as Record<string, unknown>)[key];
+  const map = enumMap as Record<string, unknown>;
+  let label = map[key];
+  if (label === undefined) {
+    const lowerKey = key.toLowerCase();
+    for (const [k, v] of Object.entries(map)) {
+      if (k.toLowerCase() === lowerKey) {
+        label = v;
+        break;
+      }
+    }
+  }
   return typeof label === "string" ? label : undefined;
 }
 

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -11,14 +11,19 @@ import type {
   DescriptorResolver,
   GitHubResolverOptions,
   GitHubSource,
+  TokenStandard,
+  TrustedTokens,
   TypedData,
   Warning,
 } from "./types.js";
+import { buildBundledTokenDescriptor } from "./bundled-descriptors.js";
 import {
   asciiToBytes,
   bytesToHex,
+  hexToBytes,
   keccak256,
   normalizeAddress,
+  toChecksumAddress,
   warn,
 } from "./utils.js";
 
@@ -61,6 +66,10 @@ async function createResolver(
  * a `{ descriptor }` envelope on success, or a `{ warning }` envelope when
  * resolution fails — `NO_DESCRIPTOR` when nothing is indexed for the pair,
  * `CYCLIC_INCLUDES` when the `includes` chain self-references.
+ *
+ * If no descriptor is indexed for the chain and address, the method also checks
+ * the optional `options.trustedTokens` list for a matching trusted token. In case
+ * of a matching trusted token, a token descriptor is generated on the fly.
  */
 export async function resolveCalldataDescriptor(
   chainId: number,
@@ -70,8 +79,37 @@ export async function resolveCalldataDescriptor(
   const resolver = await createResolver(options);
   const path =
     resolver.index.calldataIndex[`eip155:${chainId}:${normalizeAddress(to)}`];
-  if (!path) return noDescriptorWarning(chainId, to);
-  return resolveWithIncludes(resolver, path);
+  if (path) return resolveWithIncludes(resolver, path);
+
+  // No registry descriptor. Check if a trusted token matches.
+  const standard = lookupTrustedToken(options?.trustedTokens, chainId, to);
+  if (standard) {
+    return { descriptor: buildBundledTokenDescriptor(standard, chainId, to) };
+  }
+
+  return noDescriptorWarning(chainId, to);
+}
+
+/**
+ * Look up a token standard in the trusted-token list, accepting either a
+ * lowercase or an EIP-55 checksummed address key.
+ */
+function lookupTrustedToken(
+  trustedTokens: TrustedTokens | undefined,
+  chainId: number,
+  address: string,
+): TokenStandard | undefined {
+  const tokens = trustedTokens?.[chainId];
+  if (!tokens) return undefined;
+
+  const lowercaseResult = tokens[normalizeAddress(address)];
+  if (lowercaseResult !== undefined) return lowercaseResult;
+
+  try {
+    return tokens[toChecksumAddress(hexToBytes(address))];
+  } catch {
+    return undefined;
+  }
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -326,7 +326,7 @@ export interface ChainInfoResult {
   };
 }
 
-/** Wallet-provided async resolvers for external data. */
+/** Wallet-provided async resolvers for external data needed by the formatter. */
 export interface ExternalDataProvider {
   /**
    * Resolution for addressName formats. The wallet should verify whether the
@@ -401,7 +401,27 @@ export interface FormatOptions {
   // resolvedImplementationAddress?: string;
 }
 
-export type GitHubResolverOptions = {
+/** Token standards for descriptor generation. */
+export type TokenStandard = "erc20" | "erc721";
+
+/** Nested map: chain ID → token address → token standard. */
+export interface TrustedTokens {
+  [chainId: number]: { [tokenAddress: string]: TokenStandard };
+}
+
+export interface BaseResolverOptions {
+  /**
+   * Wallet-provided trusted token list. Used to generate descriptors for tokens
+   * on the fly. Standard tokens usually don't have a descriptor in the registry.
+   * Without this option, the library can't format calls to standard tokens.
+   * Only wallet-trusted tokens should be included in this object.
+   *
+   * Both lowercase and checksummed token addresses are accepted.
+   */
+  trustedTokens?: TrustedTokens;
+}
+
+export type GitHubResolverOptions = BaseResolverOptions & {
   type: "github";
   /**
    * Pre-built registry index. Strongly recommended: fetch once at app
@@ -419,7 +439,7 @@ export type GitHubResolverOptions = {
  * registry — filesystem (see `@ethereum-sourcify/clear-signing/filesystem`),
  * in-memory map, custom HTTP endpoint, etc.
  */
-export type CustomResolverOptions = {
+export type CustomResolverOptions = BaseResolverOptions & {
   type: "custom";
   resolver: DescriptorResolver;
 };
@@ -453,7 +473,7 @@ export interface RegistryIndex {
    * silently truncates `..` traversals — store `"registry/foo/main.json"`,
    * not `"main.json"`, if the include chain reaches a sibling directory.
    */
-  calldataIndex: Record<string, string>;
+  calldataIndex: { [caip10Id: string]: string };
 
   /**
    * Maps CAIP-10 identifiers to a per-primary-type list of descriptor entries.
@@ -470,7 +490,9 @@ export interface RegistryIndex {
    * See https://github.com/ethereum/clear-signing-erc7730-registry/blob/master/index.eip712.json
    * as an example of the shape of this index in practice.
    */
-  typedDataIndex: Record<string, Record<string, TypedDataIndexEntry[]>>;
+  typedDataIndex: {
+    [caip10Id: string]: { [primaryType: string]: TypedDataIndexEntry[] };
+  };
 }
 
 /**

--- a/test/bundled/registry-erc20.json
+++ b/test/bundled/registry-erc20.json
@@ -1,0 +1,21 @@
+{
+  "context": {
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0xA0b86991c6218b36c1d19D4a2E9Eb0cE3606eB48"
+        }
+      ]
+    }
+  },
+  "metadata": { "owner": "Registry Owner" },
+  "display": {
+    "formats": {
+      "transfer(address _to,uint256 _value)": {
+        "intent": "Registry Send",
+        "fields": [{ "path": "_to", "label": "Recipient", "format": "raw" }]
+      }
+    }
+  }
+}

--- a/test/bundled/trusted-tokens.spec.ts
+++ b/test/bundled/trusted-tokens.spec.ts
@@ -1,0 +1,340 @@
+/**
+ * Trusted-token bundled descriptors: when no registry descriptor resolves for
+ * a contract, a wallet-supplied `trustedTokens` list lets the library render
+ * the transaction from a bundled ERC-20 / ERC-721 template.
+ */
+
+import { describe, it, expect, assert } from "vitest";
+import { format, isFieldGroup } from "../../src/index.js";
+import type {
+  DisplayModel,
+  ExternalDataProvider,
+  FormatOptions,
+  TrustedTokens,
+} from "../../src/types.js";
+import { hexToBytes, toChecksumAddress } from "../../src/utils.js";
+import { buildFilesystemResolverOpts } from "../utils.js";
+
+const CHAIN_ID = 1;
+const TOKEN = "0xA0b86991c6218b36c1d19D4a2E9Eb0cE3606eB48";
+const COLLECTION = "0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D";
+const ALICE = "0x1234567890abcdef1234567890abcdef12345678";
+const ALICE_NAME = "Alice";
+const OPERATOR = "0xabcabcabcabcabcabcabcabcabcabcabcabcabca";
+const MAX_UINT256 =
+  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+
+const checksum = (addr: string) => toChecksumAddress(hexToBytes(addr));
+const word = (hex: string) => hex.padStart(64, "0");
+const addrWord = (addr: string) => word(addr.slice(2).toLowerCase());
+
+const externalData: ExternalDataProvider = {
+  resolveToken: async (chainId, address) =>
+    chainId === CHAIN_ID && address === TOKEN.toLowerCase()
+      ? { name: "Test Token", symbol: "TKN", decimals: 6 }
+      : null,
+  resolveLocalName: async (address) =>
+    address.toLowerCase() === ALICE.toLowerCase()
+      ? { name: ALICE_NAME, typeMatch: true }
+      : null,
+  resolveNftCollectionName: async (chainId, address) =>
+    chainId === CHAIN_ID && address.toLowerCase() === COLLECTION.toLowerCase()
+      ? { name: "Cool Cats" }
+      : null,
+};
+
+const TRUSTED_ERC20: TrustedTokens = {
+  [CHAIN_ID]: { [TOKEN.toLowerCase()]: "erc20" },
+};
+const TRUSTED_ERC721: TrustedTokens = {
+  [CHAIN_ID]: { [COLLECTION.toLowerCase()]: "erc721" },
+};
+
+/** FormatOptions with an empty registry index (no network) + a trusted-token list. */
+function opts(
+  trustedTokens: TrustedTokens,
+  externalDataProvider: ExternalDataProvider = externalData,
+): FormatOptions {
+  return {
+    descriptorResolverOptions: {
+      type: "github",
+      index: { calldataIndex: {}, typedDataIndex: {} },
+      trustedTokens,
+    },
+    externalDataProvider,
+  };
+}
+
+describe("trusted tokens — bundled ERC-20", () => {
+  it("formats transfer(address,uint256) as Send", async () => {
+    const data = "0xa9059cbb" + addrWord(ALICE) + word("f4240"); // value = 1_000_000
+    const result: DisplayModel = await format(
+      { chainId: CHAIN_ID, to: TOKEN, data },
+      opts(TRUSTED_ERC20),
+    );
+
+    expect(result.intent).toBe("Send");
+    expect(result.interpolatedIntent).toBeUndefined();
+    expect(result.rawCalldataFallback).toBeUndefined();
+    expect(result.warnings).toBeUndefined();
+    // The bundled ERC-20 template carries no metadata.
+    expect(result.metadata).toBeUndefined();
+
+    assert(result.fields);
+    expect(result.fields).toHaveLength(2);
+
+    const amount = result.fields[0];
+    assert(!isFieldGroup(amount));
+    expect(amount.label).toBe("Amount");
+    expect(amount.value).toBe("1 TKN");
+    expect(amount.fieldType).toBe("uint");
+    expect(amount.format).toBe("tokenAmount");
+    expect(amount.tokenAddress).toBe(checksum(TOKEN));
+    expect(amount.rawAddress).toBeUndefined();
+    expect(amount.embeddedCalldata).toBeUndefined();
+    expect(amount.warning).toBeUndefined();
+
+    const to = result.fields[1];
+    assert(!isFieldGroup(to));
+    expect(to.label).toBe("To");
+    expect(to.value).toBe(ALICE_NAME);
+    expect(to.fieldType).toBe("address");
+    expect(to.format).toBe("addressName");
+    expect(to.rawAddress).toBe(checksum(ALICE));
+    expect(to.tokenAddress).toBeUndefined();
+    expect(to.embeddedCalldata).toBeUndefined();
+    expect(to.warning).toBeUndefined();
+  });
+
+  it("formats approve(address,uint256) over threshold as Unlimited", async () => {
+    const data = "0x095ea7b3" + addrWord(OPERATOR) + MAX_UINT256;
+    const result = await format(
+      { chainId: CHAIN_ID, to: TOKEN, data },
+      opts(TRUSTED_ERC20),
+    );
+
+    expect(result.intent).toBe("Approve");
+    expect(result.warnings).toBeUndefined();
+    assert(result.fields);
+    expect(result.fields).toHaveLength(2);
+
+    const spender = result.fields[0];
+    assert(!isFieldGroup(spender));
+    expect(spender.label).toBe("Spender");
+    expect(spender.value).toBe(checksum(OPERATOR));
+    expect(spender.fieldType).toBe("address");
+    expect(spender.format).toBe("addressName");
+    expect(spender.rawAddress).toBe(checksum(OPERATOR));
+    expect(spender.tokenAddress).toBeUndefined();
+    expect(spender.embeddedCalldata).toBeUndefined();
+    // OPERATOR is not resolvable by the mock provider.
+    expect(spender.warning?.code).toBe("UNKNOWN_ADDRESS");
+
+    const amount = result.fields[1];
+    assert(!isFieldGroup(amount));
+    expect(amount.label).toBe("Amount");
+    expect(amount.value).toBe("Unlimited TKN");
+    expect(amount.fieldType).toBe("uint");
+    expect(amount.format).toBe("tokenAmount");
+    expect(amount.tokenAddress).toBe(checksum(TOKEN));
+    expect(amount.rawAddress).toBeUndefined();
+    expect(amount.embeddedCalldata).toBeUndefined();
+    expect(amount.warning).toBeUndefined();
+  });
+});
+
+describe("trusted tokens — bundled ERC-721", () => {
+  it("formats safeTransferFrom(address,address,uint256) as Send NFT", async () => {
+    const data =
+      "0x42842e0e" + addrWord(ALICE) + addrWord(OPERATOR) + word("539"); // tokenId 1337
+    const result = await format(
+      { chainId: CHAIN_ID, to: COLLECTION, data },
+      opts(TRUSTED_ERC721),
+    );
+
+    expect(result.intent).toBe("Send NFT");
+    expect(result.warnings).toBeUndefined();
+    assert(result.fields);
+    expect(result.fields).toHaveLength(3);
+
+    const from = result.fields[0];
+    assert(!isFieldGroup(from));
+    expect(from.label).toBe("From");
+    expect(from.value).toBe(ALICE_NAME);
+    expect(from.format).toBe("addressName");
+    expect(from.fieldType).toBe("address");
+    expect(from.rawAddress).toBe(checksum(ALICE));
+    expect(from.warning).toBeUndefined();
+
+    const to = result.fields[1];
+    assert(!isFieldGroup(to));
+    expect(to.label).toBe("To");
+    expect(to.value).toBe(checksum(OPERATOR));
+    expect(to.format).toBe("addressName");
+    expect(to.rawAddress).toBe(checksum(OPERATOR));
+    expect(to.warning?.code).toBe("UNKNOWN_ADDRESS");
+
+    const nft = result.fields[2];
+    assert(!isFieldGroup(nft));
+    expect(nft.label).toBe("NFT");
+    expect(nft.value).toBe("Cool Cats #1337");
+    expect(nft.format).toBe("nftName");
+    expect(nft.fieldType).toBe("uint");
+    expect(nft.tokenAddress).toBeUndefined();
+    expect(nft.rawAddress).toBeUndefined();
+    expect(nft.embeddedCalldata).toBeUndefined();
+    expect(nft.warning).toBeUndefined();
+  });
+
+  it("formats setApprovalForAll(address,bool); enum-on-bool falls back to raw", async () => {
+    const data = "0xa22cb465" + addrWord(OPERATOR) + word("1"); // approved = true
+    const result = await format(
+      { chainId: CHAIN_ID, to: COLLECTION, data },
+      opts(TRUSTED_ERC721),
+    );
+
+    expect(result.intent).toBe("Manage operator rights for");
+    assert(result.fields);
+    expect(result.fields).toHaveLength(3);
+
+    const collection = result.fields[0];
+    assert(!isFieldGroup(collection));
+    expect(collection.label).toBe("Collection");
+    expect(collection.value).toBe(checksum(COLLECTION));
+    expect(collection.format).toBe("addressName");
+    expect(collection.rawAddress).toBe(checksum(COLLECTION));
+    expect(collection.warning?.code).toBe("UNKNOWN_ADDRESS");
+
+    const operator = result.fields[1];
+    assert(!isFieldGroup(operator));
+    expect(operator.label).toBe("Operator");
+    expect(operator.value).toBe(checksum(OPERATOR));
+    expect(operator.format).toBe("addressName");
+
+    // The bundled descriptor models access rights as an enum over a bool, but
+    // the library's enum format only accepts uint/int — so it renders the raw
+    // bool with an ARGUMENT_TYPE_MISMATCH warning (known limitation).
+    const rights = result.fields[2];
+    assert(!isFieldGroup(rights));
+    expect(rights.label).toBe("Access rights");
+    expect(rights.value).toBe("true");
+    expect(rights.fieldType).toBe("bool");
+    expect(rights.format).toBe("enum");
+    expect(rights.warning?.code).toBe("ARGUMENT_TYPE_MISMATCH");
+  });
+});
+
+describe("trusted tokens — selector collision (standard comes from the tag)", () => {
+  // approve(address,uint256) shares selector 0x095ea7b3 across both standards.
+  const APPROVE = "0x095ea7b3" + addrWord(OPERATOR) + word("4c4b40"); // 5_000_000
+
+  it("renders the third word as a token amount when tagged erc20", async () => {
+    const result = await format(
+      { chainId: CHAIN_ID, to: TOKEN, data: APPROVE },
+      opts(TRUSTED_ERC20),
+    );
+    expect(result.intent).toBe("Approve");
+    assert(result.fields);
+    const amount = result.fields[1];
+    assert(!isFieldGroup(amount));
+    expect(amount.label).toBe("Amount");
+    expect(amount.value).toBe("5 TKN");
+    expect(amount.format).toBe("tokenAmount");
+  });
+
+  it("renders the same word as an NFT id when tagged erc721", async () => {
+    const result = await format(
+      { chainId: CHAIN_ID, to: COLLECTION, data: APPROVE },
+      opts(TRUSTED_ERC721),
+    );
+    expect(result.intent).toBe("Approve operator for NFT");
+    assert(result.fields);
+    expect(result.fields).toHaveLength(2);
+
+    const operator = result.fields[0];
+    assert(!isFieldGroup(operator));
+    expect(operator.label).toBe("Operator");
+    expect(operator.format).toBe("addressName");
+
+    const nft = result.fields[1];
+    assert(!isFieldGroup(nft));
+    expect(nft.label).toBe("NFT");
+    expect(nft.value).toBe("Cool Cats #5000000");
+    expect(nft.format).toBe("nftName");
+    expect(nft.fieldType).toBe("uint");
+  });
+});
+
+describe("trusted tokens — precedence and fallbacks", () => {
+  const TRANSFER = "0xa9059cbb" + addrWord(ALICE) + word("f4240"); // transfer 1 TKN
+
+  it("registry descriptor takes precedence over a trusted tag", async () => {
+    const fsOpts = buildFilesystemResolverOpts(
+      __dirname,
+      {
+        calldataDescriptorFiles: [
+          { chainId: CHAIN_ID, address: TOKEN, file: "registry-erc20.json" },
+        ],
+      },
+      externalData,
+    );
+    const resolverOptions = fsOpts.descriptorResolverOptions;
+    assert(resolverOptions);
+    const result = await format(
+      { chainId: CHAIN_ID, to: TOKEN, data: TRANSFER },
+      {
+        ...fsOpts,
+        descriptorResolverOptions: {
+          ...resolverOptions,
+          trustedTokens: TRUSTED_ERC20,
+        },
+      },
+    );
+
+    // Registry "Registry Send" intent wins over the bundled "Send".
+    expect(result.intent).toBe("Registry Send");
+    expect(result.metadata?.owner).toBe("Registry Owner");
+    assert(result.fields);
+    expect(result.fields).toHaveLength(1);
+    const field = result.fields[0];
+    assert(!isFieldGroup(field));
+    expect(field.label).toBe("Recipient");
+    expect(field.format).toBe("raw");
+  });
+
+  it("uses the bundled descriptor only when the registry misses", async () => {
+    const result = await format(
+      { chainId: CHAIN_ID, to: TOKEN, data: TRANSFER },
+      opts(TRUSTED_ERC20),
+    );
+    expect(result.intent).toBe("Send");
+    expect(result.warnings).toBeUndefined();
+  });
+
+  it("returns NO_DESCRIPTOR when untrusted and unindexed", async () => {
+    const result = await format(
+      { chainId: CHAIN_ID, to: TOKEN, data: TRANSFER },
+      opts({}),
+    );
+    expect(result.intent).toBeUndefined();
+    expect(result.fields).toBeUndefined();
+    assert(result.warnings);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].code).toBe("NO_DESCRIPTOR");
+    assert(result.rawCalldataFallback);
+    expect(result.rawCalldataFallback.selector).toBe("0xa9059cbb");
+  });
+
+  it("matches a trusted token keyed by its EIP-55 checksum address", async () => {
+    // Key the map by the canonical checksum form rather than lowercase.
+    const trusted: TrustedTokens = {
+      [CHAIN_ID]: { [checksum(TOKEN)]: "erc20" },
+    };
+    const result = await format(
+      { chainId: CHAIN_ID, to: TOKEN, data: TRANSFER },
+      opts(trusted),
+    );
+    expect(result.intent).toBe("Send");
+    expect(result.warnings).toBeUndefined();
+  });
+});

--- a/test/bundled/trusted-tokens.spec.ts
+++ b/test/bundled/trusted-tokens.spec.ts
@@ -186,7 +186,7 @@ describe("trusted tokens — bundled ERC-721", () => {
     expect(nft.warning).toBeUndefined();
   });
 
-  it("formats setApprovalForAll(address,bool); enum-on-bool falls back to raw", async () => {
+  it("formats setApprovalForAll(address,bool) with the bool rendered as an enum", async () => {
     const data = "0xa22cb465" + addrWord(OPERATOR) + word("1"); // approved = true
     const result = await format(
       { chainId: CHAIN_ID, to: COLLECTION, data },
@@ -211,16 +211,35 @@ describe("trusted tokens — bundled ERC-721", () => {
     expect(operator.value).toBe(checksum(OPERATOR));
     expect(operator.format).toBe("addressName");
 
-    // The bundled descriptor models access rights as an enum over a bool, but
-    // the library's enum format only accepts uint/int — so it renders the raw
-    // bool with an ARGUMENT_TYPE_MISMATCH warning (known limitation).
+    // The bundled descriptor models access rights as an enum over a bool; the
+    // bool `true` resolves against the capitalized "True" key.
     const rights = result.fields[2];
     assert(!isFieldGroup(rights));
     expect(rights.label).toBe("Access rights");
-    expect(rights.value).toBe("true");
+    expect(rights.value).toBe("Grant all");
     expect(rights.fieldType).toBe("bool");
     expect(rights.format).toBe("enum");
-    expect(rights.warning?.code).toBe("ARGUMENT_TYPE_MISMATCH");
+    expect(rights.rawAddress).toBeUndefined();
+    expect(rights.tokenAddress).toBeUndefined();
+    expect(rights.embeddedCalldata).toBeUndefined();
+    expect(rights.warning).toBeUndefined();
+  });
+
+  it("formats setApprovalForAll(address,bool) with approved=false as Deny all", async () => {
+    const data = "0xa22cb465" + addrWord(OPERATOR) + word("0"); // approved = false
+    const result = await format(
+      { chainId: CHAIN_ID, to: COLLECTION, data },
+      opts(TRUSTED_ERC721),
+    );
+
+    assert(result.fields);
+    const rights = result.fields[2];
+    assert(!isFieldGroup(rights));
+    expect(rights.label).toBe("Access rights");
+    expect(rights.value).toBe("Deny all");
+    expect(rights.fieldType).toBe("bool");
+    expect(rights.format).toBe("enum");
+    expect(rights.warning).toBeUndefined();
   });
 });
 

--- a/test/formatters.spec.ts
+++ b/test/formatters.spec.ts
@@ -1319,6 +1319,15 @@ describe("resolveEnumLabel", () => {
     expect(resolveEnumLabel(field, "99", metadata)).toBeUndefined();
   });
 
+  it("matches keys case-insensitively (e.g. bool 'true' → 'True')", () => {
+    const meta: DescriptorMetadata = {
+      enums: { rights: { True: "Grant all", False: "Deny all" } },
+    };
+    const field = { params: { $ref: "$.metadata.enums.rights" } };
+    expect(resolveEnumLabel(field, "true", meta)).toBe("Grant all");
+    expect(resolveEnumLabel(field, "false", meta)).toBe("Deny all");
+  });
+
   it("returns undefined when no $ref param", () => {
     expect(resolveEnumLabel({}, "0", metadata)).toBeUndefined();
   });
@@ -1366,7 +1375,17 @@ describe("formatEnum", () => {
     expect(result.rendered).toBe("Active");
   });
 
-  it("returns type mismatch for non-uint/int", () => {
+  it("accepts bool values, matching keys case-insensitively", () => {
+    const meta: DescriptorMetadata = {
+      enums: { rights: { True: "Grant all", False: "Deny all" } },
+    };
+    const field = { params: { $ref: "$.metadata.enums.rights" } };
+    expect(formatEnum(field, bool(true), meta).rendered).toBe("Grant all");
+    expect(formatEnum(field, bool(true), meta).warning).toBeUndefined();
+    expect(formatEnum(field, bool(false), meta).rendered).toBe("Deny all");
+  });
+
+  it("returns type mismatch for non-uint/int/bool", () => {
     const field = { params: { $ref: "$.metadata.enums.status" } };
     const result = formatEnum(field, str("hello"), metadata);
     expect(result.warning?.code).toBe("ARGUMENT_TYPE_MISMATCH");


### PR DESCRIPTION
Closes #16 

## Summary

- Adds an optional `trustedTokens` map to `descriptorResolverOptions` (`chainId → tokenAddress → standard`). When no registry descriptor resolves for a contract, a listed token is rendered from a bundled ERC-20 / ERC-721 template descriptor instead of falling back to raw calldata. Registry descriptors always take precedence.
- Bundles the registry ERC-20/721 templates as TypeScript consts in `src/bundled/`; `buildBundledTokenDescriptor()` injects the deployment so the binding check passes.
- The wallet must tag each token's standard — ERC-20 and ERC-721 share `approve`/`transferFrom` selectors, so calldata cannot disambiguate them. Address keys are matched lowercase or EIP-55 checksummed.
- Extends the `enum` format to accept `bool` values (resolving labels case-insensitively), so the bundled ERC-721 `setApprovalForAll` renders "Grant all"/"Deny all" instead of a raw bool with a warning.
- Updates GUIDE.md, README.md, and AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)