### PR TITLE
Support visible.mustBe rules

### DIFF
--- a/src/descriptor.ts
+++ b/src/descriptor.ts
@@ -100,7 +100,7 @@ export type BytesSliceValue = { type: "bytes-slice"; bytes: Uint8Array };
 
 /**
  * Convert a raw JS value (a literal from a parsed descriptor, an EIP-712
- * message value, or an `ifNotIn`/`mustMatch` candidate) into an ArgumentValue
+ * message value, or an `ifNotIn`/`mustBe` candidate) into an ArgumentValue
  * by inferring its type from the value's shape.
  *
  * Inference rules:

--- a/src/fields.ts
+++ b/src/fields.ts
@@ -205,6 +205,14 @@ async function processSingleField(
     };
   }
 
+  const visibility = evaluateVisibility(
+    merged.visible,
+    valueForVisibility(resolvedValue, merged.format),
+    merged.label ?? merged.path ?? String(merged.value),
+  );
+  if ("warning" in visibility) return { warnings: [visibility.warning] };
+  if (visibility.hide) return { field: null };
+
   if (!merged.format || !merged.label) {
     return {
       warnings: [
@@ -223,10 +231,6 @@ async function processSingleField(
     resolvedValue,
     merged.format,
   );
-
-  const visibility = evaluateVisibility(merged.visible, argValue, merged.label);
-  if ("warning" in visibility) return { warnings: [visibility.warning] };
-  if (visibility.hide) return { field: null };
 
   const {
     rendered,
@@ -777,8 +781,9 @@ type VisibilityResult = { hide: boolean } | { warning: Warning };
  *
  *   - "always" / "optional" / undefined → shown
  *   - { ifNotIn: [...] }                 → hidden when the value matches any entry
- *   - { mustMatch: [...] }               → always hidden; emits a MUSTMATCH_VIOLATION
+ *   - { mustBe: [...] }                  → always hidden; emits a MUSTMATCH_VIOLATION
  *                                          warning when the value does NOT match
+ *   - { mustMatch: [...] }               → legacy alias for mustBe
  */
 function evaluateVisibility(
   visible: DescriptorFieldFormat["visible"],
@@ -793,8 +798,15 @@ function evaluateVisibility(
     return { hide: matchesAnyCandidate(argValue, visible.ifNotIn) };
   }
 
-  if ("mustMatch" in visible && visible.mustMatch) {
-    if (matchesAnyCandidate(argValue, visible.mustMatch)) {
+  const mustBe =
+    "mustBe" in visible && visible.mustBe
+      ? visible.mustBe
+      : "mustMatch" in visible && visible.mustMatch
+        ? visible.mustMatch
+        : undefined;
+
+  if (mustBe) {
+    if (matchesAnyCandidate(argValue, mustBe)) {
       return { hide: true };
     }
     return {
@@ -806,6 +818,15 @@ function evaluateVisibility(
   }
 
   return { hide: false };
+}
+
+function valueForVisibility(
+  value: ArgumentValue | BytesSliceValue,
+  format: DescriptorFieldFormatType | undefined,
+): ArgumentValue {
+  if (format) return coerceResolvedValue(value, format);
+  if (value.type !== "bytes-slice") return value;
+  return { type: "bytes", bytes: value.bytes };
 }
 
 function matchesAnyCandidate(

--- a/src/types.ts
+++ b/src/types.ts
@@ -580,6 +580,7 @@ export interface DescriptorFieldFormat {
     | "always"
     | "optional"
     | { ifNotIn?: Array<string | number | boolean | null> }
+    | { mustBe?: Array<string | number | boolean | null> }
     | { mustMatch?: Array<string | number | boolean | null> };
   separator?: string;
   encryption?: DescriptorFieldEncryption;

--- a/test/erc7730-test-cases/example-visibility-rules.json
+++ b/test/erc7730-test-cases/example-visibility-rules.json
@@ -62,9 +62,8 @@
             "$id": "Legacy is an unused field that must be zero or the Tx is malformed",
             "path": "legacy",
             "label": "Legacy Amount",
-            "format": "raw",
             "visible": {
-              "mustMatch": [0]
+              "mustBe": [0]
             }
           },
           {

--- a/test/erc7730-test-cases/example-visibility-rules.spec.ts
+++ b/test/erc7730-test-cases/example-visibility-rules.spec.ts
@@ -1,6 +1,6 @@
 /**
  * Tests based on the ERC-7730 spec test case: example-visibility-rules.json
- * Tests the per-field `visible` rule (always / never / optional / ifNotIn / mustMatch).
+ * Tests the per-field `visible` rule (always / never / optional / ifNotIn / mustBe).
  * @see https://eips.ethereum.org/EIPS/eip-7730#field-format-specification
  */
 
@@ -110,7 +110,7 @@ function buildOpts(externalDataProvider?: ExternalDataProvider): FormatOptions {
 }
 
 describe("example-visibility-rules.json — transfer with visibility rules", () => {
-  it("shows always/optional fields and hides never/mustMatch fields when values are as expected", async () => {
+  it("shows always/optional fields and hides never/mustBe fields when values are as expected", async () => {
     const opts = buildOpts({
       resolveToken,
       resolveLocalName,
@@ -126,7 +126,7 @@ describe("example-visibility-rules.json — transfer with visibility rules", () 
           value: TRANSFER_AMOUNT,
           referrer: REFERRER,
           rfu: RFU,
-          legacy: 0n, // mustMatch [0] → matches, hidden without warning
+          legacy: 0n, // mustBe [0] → matches, hidden without warning
           fee: FEE_1_ETH, // ifNotIn [0] → not in, shown
         }),
       },
@@ -137,7 +137,7 @@ describe("example-visibility-rules.json — transfer with visibility rules", () 
 
     assert(result.fields);
     // Displayed: To (always), Amount (always), Referrer (optional), Fee (ifNotIn, value != 0)
-    // Hidden:    RFU (never), Legacy (mustMatch with matching value)
+    // Hidden:    RFU (never), Legacy (mustBe with matching value)
     expect(result.fields).toHaveLength(4);
 
     const toField = result.fields[0];
@@ -225,7 +225,7 @@ describe("example-visibility-rules.json — transfer with visibility rules", () 
     );
 
     assert(result.fields);
-    // Hidden: RFU (never), Legacy (mustMatch match), Fee (ifNotIn match)
+    // Hidden: RFU (never), Legacy (mustBe match), Fee (ifNotIn match)
     expect(result.fields).toHaveLength(3);
 
     const labels = result.fields.map((f) => {
@@ -274,7 +274,7 @@ describe("example-visibility-rules.json — transfer with visibility rules", () 
     expect(result.warnings).toBeUndefined();
   });
 
-  it("falls back to rawCalldataFallback when a mustMatch field value does not match", async () => {
+  it("falls back to rawCalldataFallback when a mustBe field value does not match", async () => {
     const opts = buildOpts({
       resolveToken,
       resolveLocalName,
@@ -290,7 +290,7 @@ describe("example-visibility-rules.json — transfer with visibility rules", () 
           value: TRANSFER_AMOUNT,
           referrer: REFERRER,
           rfu: RFU,
-          legacy: 42n, // violates mustMatch: [0]
+          legacy: 42n, // violates mustBe: [0]
           fee: FEE_1_ETH,
         }),
       },

--- a/test/fields.spec.ts
+++ b/test/fields.spec.ts
@@ -105,6 +105,70 @@ describe("applyFieldFormats", () => {
       expect(field.label).toBe("Amount");
     });
 
+    it("skips fields with visible.mustBe before requiring a format", async () => {
+      const format: DescriptorFormatSpec = {
+        fields: [
+          { path: "amount", label: "Amount", format: "raw" },
+          {
+            path: "invariant",
+            label: "Invariant",
+            visible: { mustBe: [0] },
+          },
+        ],
+      };
+      const resolvePath = mapResolvePath({
+        amount: UINT(1n),
+        invariant: UINT(0n),
+      });
+
+      const result = await applyFieldFormats(
+        format,
+        {},
+        resolvePath,
+        mapArrayLength({}),
+        1,
+        undefined,
+      );
+
+      assert(!("warnings" in result));
+      expect(result.fields).toHaveLength(1);
+      const field = result.fields[0];
+      assert(!isFieldGroup(field));
+      expect(field.label).toBe("Amount");
+    });
+
+    it("supports visible.mustMatch as a legacy alias for mustBe", async () => {
+      const format: DescriptorFormatSpec = {
+        fields: [
+          { path: "amount", label: "Amount", format: "raw" },
+          {
+            path: "legacyInvariant",
+            label: "Legacy Invariant",
+            visible: { mustMatch: [0] },
+          },
+        ],
+      };
+      const resolvePath = mapResolvePath({
+        amount: UINT(1n),
+        legacyInvariant: UINT(0n),
+      });
+
+      const result = await applyFieldFormats(
+        format,
+        {},
+        resolvePath,
+        mapArrayLength({}),
+        1,
+        undefined,
+      );
+
+      assert(!("warnings" in result));
+      expect(result.fields).toHaveLength(1);
+      const field = result.fields[0];
+      assert(!isFieldGroup(field));
+      expect(field.label).toBe("Amount");
+    });
+
     it("merges field with $ref definition", async () => {
       const definitions: Record<string, DescriptorFieldFormat> = {
         myDef: { label: "Defined Label", format: "raw" },


### PR DESCRIPTION
## Summary

- Add support for schema-standard `visible.mustBe` while preserving `mustMatch` as a legacy alias.
- Evaluate visibility rules for hidden validation fields before requiring render-only field properties like `format`.
- Update visibility-rule fixtures and unit tests for hidden `mustBe` fields without render formats.

This lets validation-only hidden fields be checked without requiring them to be renderable. Without this change, those hidden guard fields are rejected before their visibility rules can be evaluated.

## Context

This was surfaced while testing the Ocarina ERC-7730 registry submission: ethereum/clear-signing-erc7730-registry#2598. That descriptor uses validation-only hidden `visible.mustBe` fields inside bundled offer/receive/tip item groups.

## Validation

- `npm test`
- `npm run check:types`
- `npm run check:prettier`
- `npm run check:eslint`