### PR TITLE
feat(encryption): support ERC-7730 encryption schemes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,9 +49,10 @@ src/
   (wraps a `BaseResolvePath` to handle slice paths transparently), and
   `bytesSliceToArgumentValue` (converts `BytesSliceValue` to `ArgumentValue` using the
   field format's expected type).
-  Also contains encryption support: `plaintextTypeToFieldType` (canonical Solidity
-  type → `FieldType`) and `decryptFieldValue` (calls the wallet's
-  `resolveDecryptedValue` and re-interprets the returned bytes via
+  Also contains encryption support: `parsePlaintextType` (canonical Solidity type
+  → `FieldType` plus the type's maximum byte width) and `decryptFieldValue`
+  (calls the wallet's `resolveDecryptedValue`, rejects a plaintext too wide for
+  its declared type, and re-interprets the returned bytes via
   `bytesSliceToFieldType`). When decryption fails, `processSingleField` substitutes
   `DEFAULT_ENCRYPTED_PLACEHOLDER` / the descriptor's `fallbackLabel` for the
   `renderField` call, so the fallback flows through the normal DisplayField path.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -504,7 +504,7 @@ Tests live in `test/`. Current test files:
 - `test/erc7730-test-cases/example-array-iteration.spec.ts` — bundled/sequential array iteration tests
 - `test/registry-cases/1inch/1inch.spec.ts` — 1inch AggregationRouterV6: swap + clipperSwap (byte slice paths)
 - `test/registry-cases/paraswap/paraswap.spec.ts` — Paraswap AugustusSwapper v6.2: RFQ batch fill (tuple array decoding) + BalancerV2 (dynamic bytes + byte range slices)
-- `test/registry-cases/zama/zama.spec.ts` — Zama ConfidentialWrapper: fhevm-encrypted `bytes32` amount handle decrypted via `resolveDecryptedValue` and rendered as a tokenAmount, plus the no-provider case falling back to the descriptor's `fallbackLabel`
+- `test/registry-cases/zama/zama.spec.ts` — Zama ConfidentialWrapper: fhevm-encrypted `bytes32` amount handle decrypted via `resolveDecryptedValue` and rendered as a tokenAmount, plus plaintext-encoding edge cases (zero-padded ABI word, top-bit-set `uint64`, over-wide value) and both fallback paths — no provider, and a provider that declines
 - `test/bundled/trusted-tokens.spec.ts` — bundled ERC-20/721 descriptors via `trustedTokens`: standard tagging, selector collision, registry precedence
 
 ### Test guidelines

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ src/
   path resolution (`resolveTransactionPath`, `resolveTypedDataPath`),
   value conversion (`ArgumentValue`, `BytesSliceValue`, `toArgumentValue`,
   `argumentValueToBytes`, `argumentValueEquals`), format-to-type mapping
-  (`fieldTypeForFormat`, `bytesSliceToFieldType`),
+  (`fieldTypeForFormat`),
   field/definition merging (`mergeDefinitions`, `resolveFieldValue`),
   metadata resolution (`resolveMetadataValue`), and template interpolation (`interpolateTemplate`).
   Defines the `BaseResolvePath` (returns `ArgumentValue`) and `ResolvePath`
@@ -49,6 +49,12 @@ src/
   (wraps a `BaseResolvePath` to handle slice paths transparently), and
   `bytesSliceToArgumentValue` (converts `BytesSliceValue` to `ArgumentValue` using the
   field format's expected type).
+  Also contains encryption support: `plaintextTypeToFieldType` (canonical Solidity
+  type → `FieldType`) and `decryptFieldValue` (calls the wallet's
+  `resolveDecryptedValue` and re-interprets the returned bytes via
+  `bytesSliceToFieldType`). When decryption fails, `processSingleField` substitutes
+  `DEFAULT_ENCRYPTED_PLACEHOLDER` / the descriptor's `fallbackLabel` for the
+  `renderField` call, so the fallback flows through the normal DisplayField path.
 
 - **`formatters.ts`** — Individual format handlers dispatched by `renderField()`.
   Includes `formatRaw`, `formatTimestamp`, `renderTokenAmount`, `formatNftName`,
@@ -70,7 +76,7 @@ src/
 - **`eip712.ts`** — Everything specific to EIP-712 typed data formatting. Contains the
   top-level `formatEip712()` entry point, `encodeType` computation and matching
   (`findFormatSpec`, `computeEncodeType`), message value navigation (`getMessageValue`),
-  and type resolution (`resolveFieldType`). Exports `computeEncodeType` and
+  and referenced-struct collection (`collectReferencedTypes`). Exports `computeEncodeType` and
   `extractPrimaryType` for `resolver.ts` and `github-registry-index.ts`; the
   rest is module-private.
 
@@ -291,9 +297,13 @@ spec. Do not add them to `DescriptorFormatSpec`.
 
 ### Field Formats
 
-Supported: `raw`, `amount`, `tokenAmount`, `nftName`, `date`, `duration`, `unit`, `enum`, `addressName`, `tokenTicker`, `chainId`
+Supported: `raw`, `amount`, `tokenAmount`, `nftName`, `date`, `duration`, `unit`, `enum`, `addressName`, `tokenTicker`, `chainId`, `calldata`
 
 Not yet implemented: `interoperableAddressName`
+
+Any field, regardless of `format`, may additionally carry an `encryption`
+annotation — see [Encrypted Fields](#encrypted-fields). It is orthogonal to the
+format: the value is decrypted first, then rendered by the format above.
 
 **Spec-compliance notes:**
 
@@ -309,7 +319,80 @@ Not yet implemented: `interoperableAddressName`
 - `tokenAmount` with `nativeCurrencyAddress` also resolves native currency metadata via `resolveChainInfo`.
 - `addressName` supports the `senderAddress` param: when the field value matches a `senderAddress`, it displays `"Sender"` and substitutes `rawAddress` with `@.from`. Checked via `isSenderAddress()`.
 - `resolveLocalName` and `resolveEnsName` receive `acceptedTypes?: DescriptorAddressType[]` (from `params.types`). The parameter is absent when the descriptor defines no `types`. Callers should check membership with `acceptedTypes?.includes(...)`. The library emits `ADDRESS_TYPE_MISMATCH` when the resolver returns `typeMatch: false`.
+- `calldata` formats a nested function call, recursing through `format()` and
+  returning the inner `DisplayModel` on `DisplayField.embeddedCalldata` (with its
+  `callee` and `chainId`). Accepts only `bytes`. Resolves the target via
+  `callee`/`calleePath` and the chain via `chainId`/`chainIdPath`, defaulting to the
+  container's chain. Optional `selector`/`selectorPath` is prepended to the value when
+  the field carries bare arguments; `amount`/`amountPath` and `spender`/`spenderPath`
+  become the inner tx's `value` and `from`. Falls back to raw with
+  `FORMAT_PARAM_RESOLUTION_ERROR` (unresolvable `callee`/`chainId` param),
+  `CONTAINER_MISSING_CHAIN_ID`, or `EMBEDDED_CALLDATA_NOT_SUPPORTED` (the caller
+  supplied no nested formatter — `index.ts` always does, so this only surfaces when
+  `formatCalldata`/`formatEip712` are driven directly).
 - Raw address rendering always uses EIP-55 checksum format (not lowercase hex).
+
+### Encrypted Fields
+
+A field may carry an `encryption` annotation (`DescriptorFieldEncryption`:
+`{ scheme, plaintextType, fallbackLabel }`) marking its value as encrypted.
+Decryption is delegated entirely to the wallet and is optional — schemes
+generally need a live connection, a user signature, and an access-control check.
+`fhevm` is the only scheme ERC-7730 currently defines; the wallet-side
+integration is documented in [`DECRYPTION.md`](DECRYPTION.md) and kept out of the
+library.
+
+The raw encrypted value is always reported on `DisplayField.rawEncryptedValue`,
+decrypted or not — the spec RECOMMENDS wallets show it next to the placeholder
+when decryption is unavailable. It is captured before `argValue` is replaced by
+the plaintext.
+
+`processSingleField` decrypts **before** visibility evaluation and rendering, so
+`ifNotIn`/`mustMatch` rules and the format handler all see the plaintext. On
+success the plaintext replaces the field's `ArgumentValue` and the regular
+`format` renders it (e.g. `tokenAmount` → `"1 cUSDC"`).
+
+Failures split by kind:
+
+- **`DECRYPTION_FAILED`** — the value is real but unavailable (no provider, no
+  chainId, wallet returned `null`, malformed hex). Recoverable: the field still
+  renders, as `fallbackLabel` or the generic `[Encrypted]` placeholder when the
+  descriptor declares none, carrying the warning rather than being dropped. The
+  ciphertext is never the display value; it travels on `rawEncryptedValue`.
+- **`INVALID_DESCRIPTOR`** — the `encryption` annotation itself is malformed
+  (missing `scheme`/`plaintextType`, or a non-canonical `plaintextType`). A
+  descriptor bug, not a decryption outcome, so it is fatal for the whole format,
+  consistent with the other `INVALID_DESCRIPTOR` checks in `processSingleField`.
+
+**Coercion is driven by the descriptor's declared `plaintextType`, never by the
+returned value's shape.** `toArgumentValue` must **not** be used here: it has no
+`bigint` case (returns `undefined`), and its shape inference would misread a
+`bytes20` plaintext as an address. `decryptFieldValue` instead maps
+`plaintextType` → `FieldType` and reuses `bytesSliceToFieldType`, mirroring how
+byte slices are coerced by expected type.
+
+Wallet contract (`ExternalDataProvider.resolveDecryptedValue`):
+
+- Receives `(chainId, encryptedValue, { scheme, contractAddress })`.
+  `encryptedValue` is 0x-hex of the raw field bytes; `contractAddress` is the
+  container's `@.to` (optional — an EIP-712 domain may declare no
+  `verifyingContract`).
+- `plaintextType` is deliberately **not** passed: the wallet has no use for it.
+  Decryption yields bytes; interpreting them is this library's job. Passing it
+  would only invite the wallet to coerce, duplicating work the library already
+  does from the descriptor.
+- Returns `DecryptedValueResult { value: string }` — 0x-hex of the plaintext's
+  big-endian bytes only, never `bigint`/`boolean`. One encoding for every scheme
+  and type, with no hex-vs-text ambiguity.
+- Returns `null` when it cannot decrypt (unsupported scheme, denied signature,
+  no access) → `DECRYPTION_FAILED`. A malformed (non-hex) `value` is treated the
+  same way: it is a failed decryption, not a distinct condition.
+
+`scheme` is typed as `DescriptorFieldEncryptionScheme`, a union of the schemes
+ERC-7730 defines (currently just `"fhevm"`), so wallets get exhaustiveness
+checking when dispatching. Add new schemes there as the spec defines them. The
+library itself never inspects the value — it only passes it to the wallet, which
+decides what it can decrypt.
 
 ### Token Resolution
 
@@ -389,6 +472,11 @@ When changing the public API, input/output types, descriptor resolver options, w
 codes, or the `ExternalDataProvider` interface, check whether [`GUIDE.md`](GUIDE.md)
 (the wallet integration guide) and [`README.md`](README.md) need updating too — they
 contain example code and type signatures that can drift out of sync with the source.
+If the change touches encryption, check [`DECRYPTION.md`](DECRYPTION.md) as well.
+
+Keep scheme-specific integration detail (SDK calls, protocol internals) in
+[`DECRYPTION.md`](DECRYPTION.md) — `src/`, `README.md`, and `GUIDE.md` stay
+scheme-agnostic and describe only the `resolveDecryptedValue` contract.
 
 ## Pull Requests
 
@@ -411,6 +499,7 @@ Tests live in `test/`. Current test files:
 - `test/erc7730-test-cases/example-array-iteration.spec.ts` — bundled/sequential array iteration tests
 - `test/registry-cases/1inch/1inch.spec.ts` — 1inch AggregationRouterV6: swap + clipperSwap (byte slice paths)
 - `test/registry-cases/paraswap/paraswap.spec.ts` — Paraswap AugustusSwapper v6.2: RFQ batch fill (tuple array decoding) + BalancerV2 (dynamic bytes + byte range slices)
+- `test/registry-cases/zama/zama.spec.ts` — Zama ConfidentialWrapper: fhevm-encrypted `bytes32` amount handle decrypted via `resolveDecryptedValue` and rendered as a tokenAmount, plus the no-provider case falling back to the descriptor's `fallbackLabel`
 - `test/bundled/trusted-tokens.spec.ts` — bundled ERC-20/721 descriptors via `trustedTokens`: standard tagging, selector collision, registry precedence
 
 ### Test guidelines
@@ -422,6 +511,10 @@ Tests live in `test/`. Current test files:
 - **Test all properties** of each `DisplayField`:
   `label`, `value`, `fieldType`, `format`, `warning`, `rawAddress`, `tokenAddress`, `embeddedCalldata`.
   Assert that properties not expected to be present are `undefined`.
+  `rawEncryptedValue` is deliberately **not** in that list — only fields carrying an
+  `encryption` annotation ever set it, so assert it in encryption tests (both on success
+  and on fallback) and leave it out of the others rather than adding `undefined` checks
+  across the suite.
 - **Test nested `DisplayModel`s** (e.g. `embeddedCalldata.display`) with the same thoroughness.
   For calldata fields also assert `embeddedCalldata.callee` and `embeddedCalldata.chainId`.
   Extract a helper function (e.g. `assertNestedDistribute`) when the same nested structure
@@ -528,5 +621,4 @@ When writing code that reads descriptor fields, always guard: `descriptor.contex
 
 ## Not Yet Implemented (from EIP-7730 spec)
 
-- `calldata` format (nested function calls)
 - `interoperableAddressName` format (ERC-7930)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -370,7 +370,11 @@ returned value's shape.** `toArgumentValue` must **not** be used here: it has no
 `bigint` case (returns `undefined`), and its shape inference would misread a
 `bytes20` plaintext as an address. `decryptFieldValue` instead maps
 `plaintextType` → `FieldType` and reuses `bytesSliceToFieldType`, mirroring how
-byte slices are coerced by expected type.
+byte slices are coerced by expected type. It also passes the declared **width**,
+which matters for signed `intN`: the wallet chose the byte length, so inferring
+the sign bit from it would read a minimally-encoded positive (`200` → `0xc8`) as
+negative. Byte slices and ABI words pass no width — there the length _is_ the
+value's width.
 
 Wallet contract (`ExternalDataProvider.resolveDecryptedValue`):
 

--- a/DECRYPTION.md
+++ b/DECRYPTION.md
@@ -1,0 +1,156 @@
+# Decrypting Encrypted Fields
+
+ERC-7730 lets a descriptor mark a field's value as encrypted. This page is the
+guide to implementing `ExternalDataProvider.resolveDecryptedValue`, which is how
+a wallet decrypts those values so the library can display them.
+
+**This is optional.** Encrypted transactions format fine without it — encrypted
+fields simply render their descriptor's `fallbackLabel` (e.g.
+`"[Encrypted Amount]"`) while every other field formats as usual. Implement it
+only if your wallet wants to show users the actual decrypted values.
+
+The spec defines encryption _schemes_, and a descriptor names the one it uses.
+**Today ERC-7730 defines exactly one: `fhevm`**, the fully homomorphic
+encryption scheme used by Zama Protocol's confidential tokens. The first half of
+this page is the scheme-agnostic contract; the second is what `fhevm`
+specifically requires.
+
+This page assumes you already have an `ExternalDataProvider` — see
+[GUIDE.md §4](GUIDE.md#4-build-the-externaldataprovider).
+
+## What the descriptor declares
+
+A descriptor marks a field's value as encrypted, telling your wallet to decrypt
+it and the library how to render the result:
+
+```jsonc
+{
+  "path": "encryptedAmount",
+  "label": "Amount",
+  "format": "tokenAmount",
+  "params": { "tokenPath": "@.to" },
+  "encryption": {
+    "scheme": "fhevm",
+    "plaintextType": "uint64",
+    "fallbackLabel": "[Encrypted Amount]",
+  },
+}
+```
+
+The library calls `resolveDecryptedValue`, then renders the plaintext with the
+field's regular `format` — so this field shows `"1 cUSDC"` once decrypted. If you
+return `null`, it shows `"[Encrypted Amount]"` with a `DECRYPTION_FAILED`
+warning (or a generic `"[Encrypted]"` when a descriptor declares no
+`fallbackLabel`). The raw handle is always reported on
+`DisplayField.rawEncryptedValue`, which the spec RECOMMENDS showing — fully or
+truncated — beside the placeholder.
+
+The division of labour: **your wallet decrypts and reports; the library
+interprets and renders.**
+
+## The callback contract
+
+Decryption sits in the wallet rather than the library because schemes generally
+need a live connection, a signature from the user, and an access-control check —
+none of which belong in a formatting library. `fhevm` needs all three. So the
+library delegates through one optional method on `ExternalDataProvider`:
+
+```typescript
+interface ExternalDataProvider {
+  // …the other resolvers
+
+  resolveDecryptedValue?: (
+    chainId: number,
+    encryptedValue: string,
+    params: {
+      scheme: DescriptorFieldEncryptionScheme;
+      contractAddress?: string;
+    },
+  ) => Promise<DecryptedValueResult | null>;
+}
+
+interface DecryptedValueResult {
+  value: string;
+}
+
+// The schemes ERC-7730 defines. A union, so a wallet dispatching on it gets
+// exhaustiveness checking as new schemes are added.
+type DescriptorFieldEncryptionScheme = "fhevm";
+```
+
+| Parameter                | Meaning                                                                                                                    |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| `chainId`                | The container's chain — the network to decrypt against.                                                                    |
+| `encryptedValue`         | 0x-hex of the raw field value. For `fhevm`, the 32-byte handle.                                                            |
+| `params.scheme`          | The descriptor's declared scheme. Dispatch on this.                                                                        |
+| `params.contractAddress` | The contract the value belongs to (the container's `@.to`). Absent when an EIP-712 domain declares no `verifyingContract`. |
+| _returns_                | `DecryptedValueResult` with the plaintext as 0x-hex, or `null` if you cannot decrypt.                                      |
+
+Four rules:
+
+- **Dispatch on `params.scheme`** and return `null` for anything you don't
+  handle. `null` is a normal outcome, not an error — it also covers a user
+  declining the signature or access being denied. The field falls back cleanly
+  to its `fallbackLabel`, so never throw for these.
+- **Return `value` as 0x-prefixed hex** of the plaintext's big-endian bytes —
+  never a `bigint` or `boolean`. See [Encoding the result](#encoding-the-result).
+- **Don't cast to the descriptor's `plaintextType`** — that's why it isn't passed
+  to you. Decryption yields bytes; typing them is the library's job.
+- **Expect one call per encrypted field.** Cache whatever your scheme makes
+  expensive and memoize by `encryptedValue` — for `fhevm` that means reusing the
+  EIP-712 signature, see [Signatures and batching](#signatures-and-batching).
+
+# The `fhevm` scheme (Zama Protocol)
+
+Everything below is specific to `fhevm`, currently the only scheme ERC-7730
+defines.
+
+## What the encrypted value actually is
+
+For `fhevm`, the `bytes32` in the calldata is **not a ciphertext**. It's a
+**handle** — a pointer into the coprocessor's off-chain ciphertext store. The
+real ciphertext is far too large to live in calldata, so the chain only ever
+moves these 32-byte references around.
+
+That means decryption is a network round-trip, not a local computation, and the
+handle is what you hand to the SDK.
+
+## Implementing the callback
+
+Zama publishes a JavaScript SDK that performs the whole round-trip: given the
+handle and the contract it belongs to, it has the user sign an EIP-712 grant
+authorising the decryption, requests it, and returns the cleartext — unsealed
+locally from an ephemeral key so it is never exposed in transit. Publicly
+decryptable values need no signature at all. See the
+[Zama Protocol documentation](https://docs.zama.org/) for setup and the current
+API; it is the authoritative source, and the signatures change between versions.
+
+Return `null` wherever you cannot complete this — an unsupported scheme, a
+missing `contractAddress`, a declined signature, or an ACL rejection.
+
+## Encoding the result
+
+`DecryptedValueResult.value` must be **0x-prefixed hex of the plaintext's
+big-endian bytes**. The SDK returns a typed JavaScript value — an integer, a
+boolean, or a hex string depending on the handle's FHE type — so integers and
+booleans need encoding before you return them.
+
+Two things are easy to get wrong:
+
+- **Pad to an even number of hex digits.** `"0x" + n.toString(16)` yields
+  `"0xf4240"` for `1000000n`, which is odd-length and rejected as a failed
+  decryption. Leading zeros are insignificant for integers, addresses and bools,
+  so zero-padding — even out to a full 32-byte word — is always safe.
+- **Convert the encoding, never the type.** The SDK already returns the value at
+  its correct type (the handle encodes it), and the descriptor already declares
+  `plaintextType` — which is why that type is not passed to your callback.
+  Hex-encode as-is and let the library interpret it.
+
+## Signatures and batching
+
+One call per encrypted field does **not** mean one signing prompt per field: the
+EIP-712 grant is scoped to a set of contracts and a time window, not to
+individual handles — so a single signature serves every handle for those
+contracts until it expires. Cache the signature and ephemeral keypair per
+`(contracts, window)` and reuse them. Memoizing decrypted values by handle avoids
+repeat round-trips within a transaction.

--- a/DECRYPTION.md
+++ b/DECRYPTION.md
@@ -135,7 +135,7 @@ big-endian bytes**. The SDK returns a typed JavaScript value — an integer, a
 boolean, or a hex string depending on the handle's FHE type — so integers and
 booleans need encoding before you return them.
 
-Three things are easy to get wrong:
+Four things are easy to get wrong:
 
 - **Pad to an even number of hex digits.** `"0x" + n.toString(16)` yields
   `"0xf4240"` for `1000000n`, which is odd-length and rejected as a failed
@@ -143,9 +143,13 @@ Three things are easy to get wrong:
 - **Keep the value within its declared type.** A plaintext too wide for the
   descriptor's `plaintextType` is also treated as a failed decryption, since
   rendering it would show a wrong number rather than an obviously broken one.
-  Zero-padding is always safe for integers, addresses and bools — a full 32-byte
-  ABI word for a `uint64` is fine, because leading zeros carry no value there.
-  For `bytesN` every byte counts, so return exactly the N bytes.
+  Zero-padding is always safe for unsigned integers, addresses and bools — a
+  full 32-byte ABI word for a `uint64` is fine, because leading zeros carry no
+  value there. For `bytesN` every byte counts, so return exactly the N bytes.
+- **Return signed `intN` at its full declared width.** `-1` as an `int64` is
+  `0xffffffffffffffff`, not `0xff` — a shortened form is ambiguous, since the
+  same bytes are a different number at a different width. Positives are read at
+  the declared width either way, so only negatives depend on this.
 - **Convert the encoding, never the type.** The SDK already returns the value at
   its correct type (the handle encodes it), and the descriptor already declares
   `plaintextType` — which is why that type is not passed to your callback.

--- a/DECRYPTION.md
+++ b/DECRYPTION.md
@@ -135,12 +135,17 @@ big-endian bytes**. The SDK returns a typed JavaScript value — an integer, a
 boolean, or a hex string depending on the handle's FHE type — so integers and
 booleans need encoding before you return them.
 
-Two things are easy to get wrong:
+Three things are easy to get wrong:
 
 - **Pad to an even number of hex digits.** `"0x" + n.toString(16)` yields
   `"0xf4240"` for `1000000n`, which is odd-length and rejected as a failed
-  decryption. Leading zeros are insignificant for integers, addresses and bools,
-  so zero-padding — even out to a full 32-byte word — is always safe.
+  decryption.
+- **Keep the value within its declared type.** A plaintext too wide for the
+  descriptor's `plaintextType` is also treated as a failed decryption, since
+  rendering it would show a wrong number rather than an obviously broken one.
+  Zero-padding is always safe for integers, addresses and bools — a full 32-byte
+  ABI word for a `uint64` is fine, because leading zeros carry no value there.
+  For `bytesN` every byte counts, so return exactly the N bytes.
 - **Convert the encoding, never the type.** The SDK already returns the value at
   its correct type (the handle encodes it), and the descriptor already declares
   `plaintextType` — which is why that type is not passed to your callback.

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -140,6 +140,15 @@ const externalDataProvider: ExternalDataProvider = {
     };
     return result;
   },
+
+  // Used by fields carrying an `encryption` annotation, to decrypt the value.
+  // Optional and scheme-specific — omit it and encrypted fields render the
+  // descriptor's `fallbackLabel` while everything else formats as usual.
+  // See DECRYPTION.md.
+  resolveDecryptedValue: async (chainId, encryptedValue, params) => {
+    const result: DecryptedValueResult | null = { value: "0x00000000000f4240" };
+    return result;
+  },
 };
 
 // Combine with the resolver options from §2 and §3 into the FormatOptions object
@@ -155,6 +164,10 @@ const opts: FormatOptions = {
 ```
 
 See [`src/types.ts`](src/types.ts) for the exact result type definitions.
+
+To decrypt encrypted fields (`resolveDecryptedValue`), see
+[DECRYPTION.md](DECRYPTION.md). It covers the scheme-agnostic contract and
+`fhevm` (Zama Protocol), the only scheme ERC-7730 currently defines.
 
 ## 5. Call the format functions
 
@@ -295,6 +308,13 @@ interface DisplayField {
   // For `calldata` format (nested function call): the formatted inner
   // transaction. See "Nesting" below.
   embeddedCalldata?: EmbeddedCalldata;
+
+  // For fields carrying an `encryption` annotation: the raw encrypted value,
+  // set whether or not decryption succeeded. When it did not (value is the
+  // `fallbackLabel` or "[Encrypted]", warning.code === "DECRYPTION_FAILED"),
+  // ERC-7730 RECOMMENDS displaying this alongside the placeholder — fully or
+  // truncated — so the user can see a real value is present but withheld.
+  rawEncryptedValue?: string;
 }
 
 // Underlying Solidity type category of a DisplayField.

--- a/README.md
+++ b/README.md
@@ -205,6 +205,20 @@ interface ExternalDataProvider {
 
   /** Resolution for chainId and amount formats. */
   resolveChainInfo?: (chainId: number) => Promise<ChainInfoResult | null>;
+
+  /**
+   * Decryption for fields carrying an `encryption` annotation. Optional and
+   * scheme-specific. Return `null` when the value cannot be decrypted — the
+   * field then renders the descriptor's `fallbackLabel`. See DECRYPTION.md.
+   */
+  resolveDecryptedValue?: (
+    chainId: number,
+    encryptedValue: string,
+    params: {
+      scheme: DescriptorFieldEncryptionScheme;
+      contractAddress?: string;
+    },
+  ) => Promise<DecryptedValueResult | null>;
 }
 ```
 

--- a/src/fields.ts
+++ b/src/fields.ts
@@ -6,6 +6,7 @@
  */
 
 import type {
+  DescriptorFieldEncryption,
   DescriptorFieldFormat,
   DescriptorFieldFormatType,
   DescriptorFieldGroup,
@@ -40,11 +41,15 @@ import {
   bigIntToBytes,
   bytesEqual,
   bytesToAscii,
+  bytesToHex,
   bytesToSignedBigInt,
   bytesToUnsignedBigInt,
+  hexToBytes,
   stripLeadingZeros,
+  toChecksumAddress,
   warn,
 } from "./utils.js";
+import type { RenderFieldResult } from "./formatters.js";
 import { renderField } from "./formatters.js";
 
 /** Callback to get the length of an array at a given container path. */
@@ -219,14 +224,59 @@ async function processSingleField(
   // Convert bytes-slice to a typed ArgumentValue based on the field format,
   // and coerce uint/int → address when the format expects an address (some
   // descriptors store addresses in uint256 slots, e.g. 1inch's `Address` type).
-  const argValue: ArgumentValue = coerceResolvedValue(
+  let argValue: ArgumentValue = coerceResolvedValue(
     resolvedValue,
     merged.format,
   );
 
+  // Encrypted fields are decrypted before anything reads the value, so that
+  // visibility rules and the format handler both see the plaintext.
+  let decryptionWarning: Warning | undefined;
+  let rawEncryptedValue: string | undefined;
+  if (merged.encryption) {
+    rawEncryptedValue = bytesToHex(argumentValueToBytes(argValue));
+    const decrypted = await decryptFieldValue(argValue, merged.encryption, ctx);
+    if ("value" in decrypted) {
+      argValue = decrypted.value;
+    } else if (decrypted.warning.code === "DECRYPTION_FAILED") {
+      // Recoverable: the value is real but cannot be shown, so the field still
+      // renders as its fallbackLabel rather than being dropped — the user sees
+      // that a value is present but withheld.
+      decryptionWarning = decrypted.warning;
+    } else {
+      // A malformed `encryption` annotation is a descriptor bug, not a
+      // decryption outcome. Fatal, like the other INVALID_DESCRIPTOR checks.
+      return { warnings: [decrypted.warning] };
+    }
+  }
+
   const visibility = evaluateVisibility(merged.visible, argValue, merged.label);
   if ("warning" in visibility) return { warnings: [visibility.warning] };
   if (visibility.hide) return { field: null };
+
+  let renderResult: RenderFieldResult;
+  if (decryptionWarning) {
+    // Without a plaintext there is nothing for the format handler to render, so
+    // stand in the descriptor's fallbackLabel (or a generic placeholder) and
+    // skip it — the ciphertext is never shown as the value, only on
+    // rawEncryptedValue.
+    renderResult = {
+      rendered:
+        merged.encryption?.fallbackLabel ?? DEFAULT_ENCRYPTED_PLACEHOLDER,
+      warning: decryptionWarning,
+    };
+  } else {
+    renderResult = await renderField(
+      argValue,
+      merged.format,
+      merged,
+      ctx.resolvePath,
+      ctx.chainId,
+      ctx.metadata,
+      ctx.externalDataProvider,
+      ctx.formatEmbeddedCalldata,
+    );
+  }
 
   const {
     rendered,
@@ -234,16 +284,7 @@ async function processSingleField(
     warning: fieldWarning,
     tokenAddress,
     rawAddress,
-  } = await renderField(
-    argValue,
-    merged.format,
-    merged,
-    ctx.resolvePath,
-    ctx.chainId,
-    ctx.metadata,
-    ctx.externalDataProvider,
-    ctx.formatEmbeddedCalldata,
-  );
+  } = renderResult;
 
   // Apply separator prefix for array elements (e.g. "Recipient {index}" → "Recipient 0")
   let finalValue = rendered;
@@ -264,6 +305,7 @@ async function processSingleField(
     ...(rawAddress && { rawAddress }),
     ...(tokenAddress && { tokenAddress }),
     ...(embeddedCalldata && { embeddedCalldata }),
+    ...(rawEncryptedValue && { rawEncryptedValue }),
   };
 
   if (merged.path) {
@@ -764,6 +806,144 @@ function coerceResolvedValue(
   }
   return value;
 }
+
+// ---------------------------------------------------------------------------
+// Encryption (ERC-7730 `encryption` field)
+// ---------------------------------------------------------------------------
+
+/**
+ * Map a descriptor's declared `plaintextType` (a canonical Solidity type, e.g.
+ * "uint64") to the FieldType used to interpret the decrypted bytes.
+ *
+ * Returns undefined for types that are not valid Solidity value types, so the
+ * caller can surface a descriptor error rather than silently guessing.
+ */
+export function plaintextTypeToFieldType(
+  plaintextType: string,
+): FieldType | undefined {
+  switch (plaintextType) {
+    case "bool":
+    case "address":
+    case "string":
+    case "bytes":
+      return plaintextType;
+  }
+
+  // uintN / intN — N must be a multiple of 8 in 8..256. The bare `uint`/`int`
+  // aliases are rejected: the spec requires canonical Solidity types.
+  const int = /^(u?)int(\d+)$/.exec(plaintextType);
+  if (int) {
+    const bits = Number(int[2]);
+    if (bits < 8 || bits > 256 || bits % 8 !== 0) return undefined;
+    return int[1] ? "uint" : "int";
+  }
+
+  // bytesN — N in 1..32.
+  const bytes = /^bytes(\d+)$/.exec(plaintextType);
+  if (bytes) {
+    const size = Number(bytes[1]);
+    return size >= 1 && size <= 32 ? "bytes" : undefined;
+  }
+
+  return undefined;
+}
+
+/**
+ * Decrypt a field value via the wallet's resolveDecryptedValue callback and
+ * re-interpret the returned bytes as the descriptor's declared plaintextType.
+ *
+ * The declared type — not the shape of the returned value — drives the
+ * conversion: the descriptor states the intent, and inferring instead would
+ * misread a `bytes20` plaintext as an address. This mirrors how byte slices
+ * are coerced by their expected type rather than by inspection.
+ *
+ * Warnings come in two kinds, which the caller handles differently:
+ * `DECRYPTION_FAILED` means the value is real but unavailable, so the field
+ * falls back to its `fallbackLabel`; `INVALID_DESCRIPTOR` means the `encryption`
+ * annotation itself is malformed, which is fatal for the whole format.
+ */
+async function decryptFieldValue(
+  encrypted: ArgumentValue,
+  encryption: DescriptorFieldEncryption,
+  ctx: FieldContext,
+): Promise<{ value: ArgumentValue } | { warning: Warning }> {
+  const { scheme, plaintextType } = encryption;
+  if (!scheme || !plaintextType) {
+    return {
+      warning: warn(
+        "INVALID_DESCRIPTOR",
+        `Field encryption requires both 'scheme' and 'plaintextType'`,
+      ),
+    };
+  }
+
+  const fieldType = plaintextTypeToFieldType(plaintextType);
+  if (!fieldType) {
+    return {
+      warning: warn(
+        "INVALID_DESCRIPTOR",
+        `Unsupported encryption plaintextType '${plaintextType}'`,
+      ),
+    };
+  }
+
+  if (ctx.chainId === undefined) {
+    return {
+      warning: warn(
+        "DECRYPTION_FAILED",
+        "Cannot decrypt a field without a chainId on the container",
+      ),
+    };
+  }
+
+  const resolveDecryptedValue = ctx.externalDataProvider?.resolveDecryptedValue;
+  if (!resolveDecryptedValue) {
+    return {
+      warning: warn(
+        "DECRYPTION_FAILED",
+        `No resolveDecryptedValue provider to decrypt '${scheme}' value`,
+      ),
+    };
+  }
+
+  // The contract the ciphertext is accessed through. Absent for EIP-712 typed
+  // data whose domain declares no verifyingContract.
+  const to = ctx.resolvePath("@.to");
+  const contractAddress =
+    to && to.type === "address" ? toChecksumAddress(to.bytes) : undefined;
+
+  const result = await resolveDecryptedValue(
+    ctx.chainId,
+    bytesToHex(argumentValueToBytes(encrypted)),
+    { scheme, contractAddress },
+  );
+  if (!result) {
+    return {
+      warning: warn("DECRYPTION_FAILED", `Could not decrypt '${scheme}' value`),
+    };
+  }
+
+  let bytes: Uint8Array;
+  try {
+    bytes = hexToBytes(result.value);
+  } catch {
+    return {
+      warning: warn(
+        "DECRYPTION_FAILED",
+        `Decrypted '${scheme}' value '${result.value}' is not valid hex`,
+      ),
+    };
+  }
+
+  return { value: bytesSliceToFieldType(bytes, fieldType) };
+}
+
+/**
+ * Placeholder for an undecryptable field whose descriptor declares no
+ * `fallbackLabel`. Deliberately generic — an encrypted field is not necessarily
+ * an amount. Reads naturally against the field's own label ("Amount: [Encrypted]").
+ */
+const DEFAULT_ENCRYPTED_PLACEHOLDER = "[Encrypted]";
 
 // ---------------------------------------------------------------------------
 // Visibility rules (ERC-7730 `visible` field)

--- a/src/fields.ts
+++ b/src/fields.ts
@@ -743,10 +743,19 @@ export function buildSliceResolvePath(resolve: BaseResolvePath): ResolvePath {
 
 /**
  * Convert raw slice bytes to an ArgumentValue for a given FieldType.
+ *
+ * `bits` sets the width used to interpret a signed `int`, which decides where
+ * the sign bit sits. Omit it when the bytes are inherently the value's full
+ * width — a byte slice or an ABI word — so the width follows their length.
+ * Pass it when the caller chose the length independently of the declared type,
+ * as a wallet does when returning a decrypted plaintext: without it, a positive
+ * value whose minimal encoding has the top bit set (`200` → `0xc8`) would be
+ * read as negative.
  */
 export function bytesSliceToFieldType(
   bytes: Uint8Array,
   fieldType: FieldType,
+  bits?: number,
 ): ArgumentValue {
   switch (fieldType) {
     case "address":
@@ -755,7 +764,7 @@ export function bytesSliceToFieldType(
     case "uint":
       return { type: "uint", value: bytesToUnsignedBigInt(bytes) };
     case "int":
-      return { type: "int", value: bytesToSignedBigInt(bytes) };
+      return { type: "int", value: bytesToSignedBigInt(bytes, bits) };
     case "bool":
       return {
         type: "bool",
@@ -870,6 +879,12 @@ export function parsePlaintextType(
  * carry no value — a wallet returning a zero-padded 32-byte ABI word is
  * accepted as long as the value itself fits. For `bytesN` every byte is part of
  * the value, so the raw length is what must fit.
+ *
+ * Only `0x00` is stripped, so a sign-extended negative (`-1` as `0xff…ff`) is
+ * rejected where its zero-padded positive counterpart would pass. That is
+ * intentional: a signed value is returned at exactly its declared width, so
+ * padding it out to a wider word is already outside the contract, and
+ * rejecting shows the fallback rather than a wrong number.
  */
 function exceedsPlaintextWidth(
   bytes: Uint8Array,
@@ -980,7 +995,16 @@ async function decryptFieldValue(
     };
   }
 
-  return { value: bytesSliceToFieldType(bytes, parsedType.fieldType) };
+  // The declared type, not the returned length, fixes the width — the wallet
+  // chose that length, and a minimally-encoded positive `intN` would otherwise
+  // read as negative.
+  return {
+    value: bytesSliceToFieldType(
+      bytes,
+      parsedType.fieldType,
+      parsedType.maxBytes === undefined ? undefined : parsedType.maxBytes * 8,
+    ),
+  };
 }
 
 /**

--- a/src/fields.ts
+++ b/src/fields.ts
@@ -811,22 +811,36 @@ function coerceResolvedValue(
 // Encryption (ERC-7730 `encryption` field)
 // ---------------------------------------------------------------------------
 
+/** A descriptor's declared `plaintextType`, parsed. */
+export type PlaintextType = {
+  /** How the decrypted bytes are interpreted. */
+  fieldType: FieldType;
+  /**
+   * Widest plaintext the type can hold, in bytes. Undefined for the unbounded
+   * types (`bytes`, `string`).
+   */
+  maxBytes?: number;
+};
+
 /**
- * Map a descriptor's declared `plaintextType` (a canonical Solidity type, e.g.
- * "uint64") to the FieldType used to interpret the decrypted bytes.
+ * Parse a descriptor's declared `plaintextType` (a canonical Solidity type,
+ * e.g. "uint64") into the FieldType used to interpret the decrypted bytes and
+ * the width that plaintext may occupy.
  *
  * Returns undefined for types that are not valid Solidity value types, so the
  * caller can surface a descriptor error rather than silently guessing.
  */
-export function plaintextTypeToFieldType(
+export function parsePlaintextType(
   plaintextType: string,
-): FieldType | undefined {
+): PlaintextType | undefined {
   switch (plaintextType) {
     case "bool":
+      return { fieldType: "bool", maxBytes: 1 };
     case "address":
+      return { fieldType: "address", maxBytes: 20 };
     case "string":
     case "bytes":
-      return plaintextType;
+      return { fieldType: plaintextType };
   }
 
   // uintN / intN — N must be a multiple of 8 in 8..256. The bare `uint`/`int`
@@ -835,17 +849,36 @@ export function plaintextTypeToFieldType(
   if (int) {
     const bits = Number(int[2]);
     if (bits < 8 || bits > 256 || bits % 8 !== 0) return undefined;
-    return int[1] ? "uint" : "int";
+    return { fieldType: int[1] ? "uint" : "int", maxBytes: bits / 8 };
   }
 
   // bytesN — N in 1..32.
   const bytes = /^bytes(\d+)$/.exec(plaintextType);
   if (bytes) {
     const size = Number(bytes[1]);
-    return size >= 1 && size <= 32 ? "bytes" : undefined;
+    if (size < 1 || size > 32) return undefined;
+    return { fieldType: "bytes", maxBytes: size };
   }
 
   return undefined;
+}
+
+/**
+ * Whether decrypted bytes are too wide for the declared plaintext type.
+ *
+ * Integers, addresses and bools are big-endian quantities, so leading zeros
+ * carry no value — a wallet returning a zero-padded 32-byte ABI word is
+ * accepted as long as the value itself fits. For `bytesN` every byte is part of
+ * the value, so the raw length is what must fit.
+ */
+function exceedsPlaintextWidth(
+  bytes: Uint8Array,
+  type: PlaintextType,
+): boolean {
+  if (type.maxBytes === undefined) return false;
+  const significant =
+    type.fieldType === "bytes" ? bytes : stripLeadingZeros(bytes);
+  return significant.length > type.maxBytes;
 }
 
 /**
@@ -877,8 +910,8 @@ async function decryptFieldValue(
     };
   }
 
-  const fieldType = plaintextTypeToFieldType(plaintextType);
-  if (!fieldType) {
+  const parsedType = parsePlaintextType(plaintextType);
+  if (!parsedType) {
     return {
       warning: warn(
         "INVALID_DESCRIPTOR",
@@ -935,7 +968,19 @@ async function decryptFieldValue(
     };
   }
 
-  return { value: bytesSliceToFieldType(bytes, fieldType) };
+  // A plaintext too wide for its declared type cannot be rendered faithfully —
+  // a 32-byte value read as a `uint64` amount would display a wildly wrong
+  // number. Treat it as a failed decryption rather than showing it.
+  if (exceedsPlaintextWidth(bytes, parsedType)) {
+    return {
+      warning: warn(
+        "DECRYPTION_FAILED",
+        `Decrypted '${scheme}' value is ${bytes.length} bytes, too wide for '${plaintextType}'`,
+      ),
+    };
+  }
+
+  return { value: bytesSliceToFieldType(bytes, parsedType.fieldType) };
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,6 +100,7 @@ export type WarningCode =
   | "UNKNOWN_CHAIN"
   | "PARAM_ARRAY_SIZE_MISMATCH"
   | "EMBEDDED_CALLDATA_NOT_SUPPORTED"
+  | "DECRYPTION_FAILED"
   | "BATCH_VALUE_TRANSFER"
   | "BATCH_CONTRACT_CREATION"
   | "BATCH_INTERPOLATION_INCOMPLETE"
@@ -193,6 +194,20 @@ export interface DisplayField {
    * back to the raw amount formatting and warning.code will be UNKNOWN_TOKEN.
    */
   tokenAddress?: string;
+
+  /**
+   * For fields carrying an `encryption` annotation, the raw encrypted value as
+   * 0x-prefixed hex — the field's value as it appears in the signing request,
+   * before decryption. Depending on the scheme this is the ciphertext itself or
+   * a pointer to it.
+   *
+   * Set whether or not decryption succeeded. When it did not, `value` is the
+   * descriptor's `fallbackLabel` (or a generic placeholder if it declares none)
+   * and `warning.code` is DECRYPTION_FAILED; the ERC-7730 spec recommends
+   * wallets also show this raw value — fully or partially — next to that
+   * placeholder, so the user can tell that a real value is present but withheld.
+   */
+  rawEncryptedValue?: string;
 }
 
 /**
@@ -326,6 +341,19 @@ export interface ChainInfoResult {
   };
 }
 
+/** Result of decrypting an encrypted field value. */
+export interface DecryptedValueResult {
+  /**
+   * The decrypted plaintext, as 0x-prefixed hex of its big-endian ABI bytes —
+   * never a `bigint`, `boolean`, or decimal string. The library re-interprets
+   * these bytes according to the descriptor's declared `plaintextType`, so a
+   * single encoding covers every scheme and every type.
+   *
+   * Must be valid, even-length hex.
+   */
+  value: string;
+}
+
 /** Wallet-provided async resolvers for external data needed by the formatter. */
 export interface ExternalDataProvider {
   /**
@@ -371,6 +399,35 @@ export interface ExternalDataProvider {
 
   /** Resolution for chainId and amount formats. */
   resolveChainInfo?: (chainId: number) => Promise<ChainInfoResult | null>;
+
+  /**
+   * Decryption for fields carrying an `encryption` annotation
+   * ({@link DescriptorFieldEncryption}). Only needed by wallets opting in to
+   * an encryption scheme — omit it and encrypted fields render their
+   * `fallbackLabel`.
+   *
+   * The wallet decrypts and reports the plaintext bytes; the library interprets
+   * them against the descriptor's declared `plaintextType`. That declared type
+   * is deliberately not passed here — decryption yields bytes, and typing them
+   * is the library's job, not the wallet's.
+   *
+   * Return `null` when the value cannot be decrypted — unsupported scheme,
+   * declined by the user, or access not granted.
+   */
+  resolveDecryptedValue?: (
+    chainId: number,
+    /** 0x-prefixed hex of the raw encrypted field value. */
+    encryptedValue: string,
+    params: {
+      /** Scheme from the descriptor. Dispatch on this. */
+      scheme: DescriptorFieldEncryptionScheme;
+      /**
+       * The contract the encrypted value belongs to (the container's `@.to`).
+       * Absent when an EIP-712 domain declares no `verifyingContract`.
+       */
+      contractAddress?: string;
+    },
+  ) => Promise<DecryptedValueResult | null>;
 }
 
 export interface FormatOptions {
@@ -534,8 +591,10 @@ export type DescriptorAddressType =
 
 export type DescriptorAddressSource = "local" | "ens";
 
+export type DescriptorFieldEncryptionScheme = "fhevm";
+
 export interface DescriptorFieldEncryption {
-  scheme?: string;
+  scheme?: DescriptorFieldEncryptionScheme;
   plaintextType?: string;
   fallbackLabel?: string;
 }

--- a/test/fields.spec.ts
+++ b/test/fields.spec.ts
@@ -11,15 +11,17 @@ import {
   bytesSliceToArgumentValue,
   bytesSliceToFieldType,
   parseByteSlice,
+  plaintextTypeToFieldType,
 } from "../src/fields.js";
 import type { ArgumentValue, BaseResolvePath } from "../src/descriptor.js";
 import { stripStructuredRootPrefix } from "../src/descriptor.js";
 import type {
+  DescriptorFieldEncryption,
   DescriptorFieldFormat,
   DescriptorFieldGroup,
   DescriptorFormatSpec,
 } from "../src/types.js";
-import { hexToBytes, isFieldGroup } from "../src/utils.js";
+import { hexToBytes, isFieldGroup, toChecksumAddress } from "../src/utils.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -760,6 +762,319 @@ describe("applyFieldFormats", () => {
       expect(result.type).toBe("bytes");
       assert(result.type === "bytes");
       expect(result.bytes[0]).toBe(0x52);
+    });
+  });
+
+  describe("plaintextTypeToFieldType", () => {
+    it("maps canonical Solidity value types to field types", () => {
+      expect(plaintextTypeToFieldType("bool")).toBe("bool");
+      expect(plaintextTypeToFieldType("address")).toBe("address");
+      expect(plaintextTypeToFieldType("string")).toBe("string");
+      expect(plaintextTypeToFieldType("uint8")).toBe("uint");
+      expect(plaintextTypeToFieldType("uint64")).toBe("uint");
+      expect(plaintextTypeToFieldType("uint256")).toBe("uint");
+      expect(plaintextTypeToFieldType("int8")).toBe("int");
+      expect(plaintextTypeToFieldType("int256")).toBe("int");
+      expect(plaintextTypeToFieldType("bytes")).toBe("bytes");
+      expect(plaintextTypeToFieldType("bytes1")).toBe("bytes");
+      expect(plaintextTypeToFieldType("bytes32")).toBe("bytes");
+    });
+
+    it("rejects non-canonical and invalid types", () => {
+      // "uint" / "int" aliases are not canonical Solidity per the ERC-7730 spec
+      expect(plaintextTypeToFieldType("uint")).toBeUndefined();
+      expect(plaintextTypeToFieldType("int")).toBeUndefined();
+      // Widths must be multiples of 8, and byte lengths within 1..32
+      expect(plaintextTypeToFieldType("uint7")).toBeUndefined();
+      expect(plaintextTypeToFieldType("uint512")).toBeUndefined();
+      expect(plaintextTypeToFieldType("bytes0")).toBeUndefined();
+      expect(plaintextTypeToFieldType("bytes33")).toBeUndefined();
+      expect(plaintextTypeToFieldType("euint64")).toBeUndefined();
+      expect(plaintextTypeToFieldType("")).toBeUndefined();
+    });
+  });
+
+  describe("encryption (end-to-end via applyFieldFormats)", () => {
+    const HANDLE =
+      "0xabcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+    const CONTRACT = "0x1111111111111111111111111111111111111111";
+
+    /** A field whose bytes32 value is an fhevm ciphertext handle. */
+    function encryptedField(
+      encryption: DescriptorFieldFormat["encryption"],
+    ): DescriptorFormatSpec {
+      return {
+        fields: [
+          { path: "amount", label: "Amount", format: "raw", encryption },
+        ],
+      };
+    }
+
+    const FHEVM_UINT64: DescriptorFieldEncryption = {
+      scheme: "fhevm",
+      plaintextType: "uint64",
+      fallbackLabel: "[Encrypted Amount]",
+    };
+
+    const resolvePath = mapResolvePath({
+      amount: { type: "bytes", bytes: hexToBytes(HANDLE) },
+      "@.to": ADDR(CONTRACT),
+    });
+
+    it("decrypts a value and re-interprets it as the declared plaintextType", async () => {
+      const result = await applyFieldFormats(
+        encryptedField(FHEVM_UINT64),
+        {},
+        resolvePath,
+        mapArrayLength({}),
+        1,
+        undefined,
+        {
+          resolveDecryptedValue: async () => ({ value: "0x00000000000f4240" }),
+        },
+      );
+
+      assert(!("warnings" in result));
+      const field = result.fields[0];
+      assert(!isFieldGroup(field));
+      expect(field.value).toBe("1000000");
+      expect(field.fieldType).toBe("uint");
+      expect(field.warning).toBeUndefined();
+      // Reported even on success, so the wallet can show the encrypted value
+      // next to the plaintext.
+      expect(field.rawEncryptedValue).toBe(HANDLE);
+      // The decrypted plaintext, not the handle, feeds interpolation
+      expect(result.renderedValues.get("amount")).toBe("1000000");
+    });
+
+    it("leaves rawEncryptedValue unset on fields with no encryption annotation", async () => {
+      const result = await applyFieldFormats(
+        { fields: [{ path: "amount", label: "Amount", format: "raw" }] },
+        {},
+        mapResolvePath({ amount: UINT(42n) }),
+        mapArrayLength({}),
+        1,
+        undefined,
+      );
+
+      assert(!("warnings" in result));
+      const field = result.fields[0];
+      assert(!isFieldGroup(field));
+      expect(field.rawEncryptedValue).toBeUndefined();
+    });
+
+    it("passes the handle, scheme and container `@.to` to the wallet", async () => {
+      const calls: unknown[] = [];
+      await applyFieldFormats(
+        encryptedField(FHEVM_UINT64),
+        {},
+        resolvePath,
+        mapArrayLength({}),
+        137,
+        undefined,
+        {
+          resolveDecryptedValue: async (chainId, encryptedValue, params) => {
+            calls.push([chainId, encryptedValue, params]);
+            return { value: "0x01" };
+          },
+        },
+      );
+
+      expect(calls).toEqual([
+        [
+          137,
+          HANDLE,
+          {
+            scheme: "fhevm",
+            contractAddress: toChecksumAddress(hexToBytes(CONTRACT)),
+          },
+        ],
+      ]);
+    });
+
+    it("omits contractAddress when the container has no `@.to`", async () => {
+      const calls: unknown[] = [];
+      await applyFieldFormats(
+        encryptedField(FHEVM_UINT64),
+        {},
+        mapResolvePath({
+          amount: { type: "bytes", bytes: hexToBytes(HANDLE) },
+        }),
+        mapArrayLength({}),
+        1,
+        undefined,
+        {
+          resolveDecryptedValue: async (_chainId, _encryptedValue, params) => {
+            calls.push(params);
+            return { value: "0x01" };
+          },
+        },
+      );
+
+      expect(calls).toEqual([{ scheme: "fhevm", contractAddress: undefined }]);
+    });
+
+    it("renders the fallbackLabel with DECRYPTION_FAILED when no provider is given", async () => {
+      const result = await applyFieldFormats(
+        encryptedField(FHEVM_UINT64),
+        {},
+        resolvePath,
+        mapArrayLength({}),
+        1,
+        undefined,
+      );
+
+      assert(!("warnings" in result));
+      const field = result.fields[0];
+      assert(!isFieldGroup(field));
+      expect(field.value).toBe("[Encrypted Amount]");
+      expect(field.fieldType).toBe("bytes");
+      expect(field.format).toBe("raw");
+      expect(field.warning?.code).toBe("DECRYPTION_FAILED");
+      // ERC-7730 recommends showing the raw value beside the placeholder
+      expect(field.rawEncryptedValue).toBe(HANDLE);
+    });
+
+    it("renders the fallbackLabel when the wallet cannot decrypt", async () => {
+      const result = await applyFieldFormats(
+        encryptedField(FHEVM_UINT64),
+        {},
+        resolvePath,
+        mapArrayLength({}),
+        1,
+        undefined,
+        { resolveDecryptedValue: async () => null },
+      );
+
+      assert(!("warnings" in result));
+      const field = result.fields[0];
+      assert(!isFieldGroup(field));
+      expect(field.value).toBe("[Encrypted Amount]");
+      expect(field.warning?.code).toBe("DECRYPTION_FAILED");
+    });
+
+    it("falls back to a generic placeholder when the descriptor declares no fallbackLabel", async () => {
+      const result = await applyFieldFormats(
+        encryptedField({ scheme: "fhevm", plaintextType: "uint64" }),
+        {},
+        resolvePath,
+        mapArrayLength({}),
+        1,
+        undefined,
+        { resolveDecryptedValue: async () => null },
+      );
+
+      assert(!("warnings" in result));
+      const field = result.fields[0];
+      assert(!isFieldGroup(field));
+      // Never the ciphertext — that would read as if it were the value. The
+      // raw value is still available on rawEncryptedValue.
+      expect(field.value).toBe("[Encrypted]");
+      expect(field.rawEncryptedValue).toBe(HANDLE);
+      expect(field.warning?.code).toBe("DECRYPTION_FAILED");
+    });
+
+    it("reports DECRYPTION_FAILED when the wallet returns invalid hex", async () => {
+      const result = await applyFieldFormats(
+        encryptedField(FHEVM_UINT64),
+        {},
+        resolvePath,
+        mapArrayLength({}),
+        1,
+        undefined,
+        // Odd-length hex — the `"0x" + n.toString(16)` bug
+        { resolveDecryptedValue: async () => ({ value: "0xf4240" }) },
+      );
+
+      assert(!("warnings" in result));
+      const field = result.fields[0];
+      assert(!isFieldGroup(field));
+      expect(field.value).toBe("[Encrypted Amount]");
+      expect(field.warning?.code).toBe("DECRYPTION_FAILED");
+    });
+
+    // A malformed `encryption` annotation is a descriptor bug rather than a
+    // decryption outcome, so it aborts the format instead of falling back.
+    it("fails with INVALID_DESCRIPTOR for an unsupported plaintextType", async () => {
+      const result = await applyFieldFormats(
+        encryptedField({
+          scheme: "fhevm",
+          plaintextType: "euint64",
+          fallbackLabel: "[Encrypted Amount]",
+        }),
+        {},
+        resolvePath,
+        mapArrayLength({}),
+        1,
+        undefined,
+        { resolveDecryptedValue: async () => ({ value: "0x0f4240" }) },
+      );
+
+      assert("warnings" in result);
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings[0].code).toBe("INVALID_DESCRIPTOR");
+      expect(result.warnings[0].message).toContain("euint64");
+    });
+
+    it("fails with INVALID_DESCRIPTOR when scheme or plaintextType is missing", async () => {
+      const result = await applyFieldFormats(
+        encryptedField({ plaintextType: "uint64" }),
+        {},
+        resolvePath,
+        mapArrayLength({}),
+        1,
+        undefined,
+        { resolveDecryptedValue: async () => ({ value: "0x0f4240" }) },
+      );
+
+      assert("warnings" in result);
+      expect(result.warnings[0].code).toBe("INVALID_DESCRIPTOR");
+    });
+
+    it("reports DECRYPTION_FAILED when the container has no chainId", async () => {
+      const result = await applyFieldFormats(
+        encryptedField(FHEVM_UINT64),
+        {},
+        resolvePath,
+        mapArrayLength({}),
+        undefined,
+        undefined,
+        { resolveDecryptedValue: async () => ({ value: "0x0f4240" }) },
+      );
+
+      assert(!("warnings" in result));
+      const field = result.fields[0];
+      assert(!isFieldGroup(field));
+      expect(field.value).toBe("[Encrypted Amount]");
+      expect(field.warning?.code).toBe("DECRYPTION_FAILED");
+    });
+
+    it("resolves `encryption` through a $ref definition", async () => {
+      const result = await applyFieldFormats(
+        {
+          fields: [{ path: "amount", $ref: "$.display.definitions.encAmount" }],
+        },
+        {
+          encAmount: {
+            label: "Amount",
+            format: "raw",
+            encryption: FHEVM_UINT64,
+          },
+        },
+        resolvePath,
+        mapArrayLength({}),
+        1,
+        undefined,
+        {
+          resolveDecryptedValue: async () => ({ value: "0x00000000000f4240" }),
+        },
+      );
+
+      assert(!("warnings" in result));
+      const field = result.fields[0];
+      assert(!isFieldGroup(field));
+      expect(field.value).toBe("1000000");
+      expect(field.warning).toBeUndefined();
     });
   });
 

--- a/test/fields.spec.ts
+++ b/test/fields.spec.ts
@@ -1076,6 +1076,56 @@ describe("applyFieldFormats", () => {
       expect(field.warning?.code).toBe("DECRYPTION_FAILED");
     });
 
+    // The declared width, not the returned length, decides where a signed
+    // value's sign bit sits — otherwise a minimally-encoded positive whose top
+    // bit happens to be set would render as a negative number.
+    it("interprets a signed plaintext at its declared width, not the returned length", async () => {
+      const asInt64 = async (value: string) => {
+        const result = await applyFieldFormats(
+          encryptedField({ scheme: "fhevm", plaintextType: "int64" }),
+          {},
+          resolvePath,
+          mapArrayLength({}),
+          1,
+          undefined,
+          { resolveDecryptedValue: async () => ({ value }) },
+        );
+        assert(!("warnings" in result));
+        const field = result.fields[0];
+        assert(!isFieldGroup(field));
+        return field;
+      };
+
+      // 200 minimally encoded is 0xc8, whose top bit is set. Read at 8 bits it
+      // would be -56; at the declared 64 it is 200.
+      expect((await asInt64("0xc8")).value).toBe("200");
+      expect((await asInt64("0x00000000000000c8")).value).toBe("200");
+      // Small positives were never affected.
+      expect((await asInt64("0x0a")).value).toBe("10");
+      // Negatives are returned at the full declared width.
+      expect((await asInt64("0xffffffffffffffff")).value).toBe("-1");
+      expect((await asInt64("0xffffffffffffff38")).value).toBe("-200");
+      // fieldType still reports the declared category
+      expect((await asInt64("0xc8")).fieldType).toBe("int");
+    });
+
+    it("keeps a narrower signed type's own width", async () => {
+      const result = await applyFieldFormats(
+        encryptedField({ scheme: "fhevm", plaintextType: "int8" }),
+        {},
+        resolvePath,
+        mapArrayLength({}),
+        1,
+        undefined,
+        { resolveDecryptedValue: async () => ({ value: "0xff" }) },
+      );
+
+      assert(!("warnings" in result));
+      const field = result.fields[0];
+      assert(!isFieldGroup(field));
+      expect(field.value).toBe("-1");
+    });
+
     it("reports DECRYPTION_FAILED when the wallet returns invalid hex", async () => {
       const result = await applyFieldFormats(
         encryptedField(FHEVM_UINT64),

--- a/test/fields.spec.ts
+++ b/test/fields.spec.ts
@@ -11,7 +11,7 @@ import {
   bytesSliceToArgumentValue,
   bytesSliceToFieldType,
   parseByteSlice,
-  plaintextTypeToFieldType,
+  parsePlaintextType,
 } from "../src/fields.js";
 import type { ArgumentValue, BaseResolvePath } from "../src/descriptor.js";
 import { stripStructuredRootPrefix } from "../src/descriptor.js";
@@ -765,32 +765,62 @@ describe("applyFieldFormats", () => {
     });
   });
 
-  describe("plaintextTypeToFieldType", () => {
-    it("maps canonical Solidity value types to field types", () => {
-      expect(plaintextTypeToFieldType("bool")).toBe("bool");
-      expect(plaintextTypeToFieldType("address")).toBe("address");
-      expect(plaintextTypeToFieldType("string")).toBe("string");
-      expect(plaintextTypeToFieldType("uint8")).toBe("uint");
-      expect(plaintextTypeToFieldType("uint64")).toBe("uint");
-      expect(plaintextTypeToFieldType("uint256")).toBe("uint");
-      expect(plaintextTypeToFieldType("int8")).toBe("int");
-      expect(plaintextTypeToFieldType("int256")).toBe("int");
-      expect(plaintextTypeToFieldType("bytes")).toBe("bytes");
-      expect(plaintextTypeToFieldType("bytes1")).toBe("bytes");
-      expect(plaintextTypeToFieldType("bytes32")).toBe("bytes");
+  describe("parsePlaintextType", () => {
+    it("maps canonical Solidity value types to field types and widths", () => {
+      expect(parsePlaintextType("bool")).toEqual({
+        fieldType: "bool",
+        maxBytes: 1,
+      });
+      expect(parsePlaintextType("address")).toEqual({
+        fieldType: "address",
+        maxBytes: 20,
+      });
+      expect(parsePlaintextType("uint8")).toEqual({
+        fieldType: "uint",
+        maxBytes: 1,
+      });
+      expect(parsePlaintextType("uint64")).toEqual({
+        fieldType: "uint",
+        maxBytes: 8,
+      });
+      expect(parsePlaintextType("uint256")).toEqual({
+        fieldType: "uint",
+        maxBytes: 32,
+      });
+      expect(parsePlaintextType("int8")).toEqual({
+        fieldType: "int",
+        maxBytes: 1,
+      });
+      expect(parsePlaintextType("int256")).toEqual({
+        fieldType: "int",
+        maxBytes: 32,
+      });
+      expect(parsePlaintextType("bytes1")).toEqual({
+        fieldType: "bytes",
+        maxBytes: 1,
+      });
+      expect(parsePlaintextType("bytes32")).toEqual({
+        fieldType: "bytes",
+        maxBytes: 32,
+      });
+    });
+
+    it("leaves the dynamic types unbounded", () => {
+      expect(parsePlaintextType("bytes")).toEqual({ fieldType: "bytes" });
+      expect(parsePlaintextType("string")).toEqual({ fieldType: "string" });
     });
 
     it("rejects non-canonical and invalid types", () => {
       // "uint" / "int" aliases are not canonical Solidity per the ERC-7730 spec
-      expect(plaintextTypeToFieldType("uint")).toBeUndefined();
-      expect(plaintextTypeToFieldType("int")).toBeUndefined();
+      expect(parsePlaintextType("uint")).toBeUndefined();
+      expect(parsePlaintextType("int")).toBeUndefined();
       // Widths must be multiples of 8, and byte lengths within 1..32
-      expect(plaintextTypeToFieldType("uint7")).toBeUndefined();
-      expect(plaintextTypeToFieldType("uint512")).toBeUndefined();
-      expect(plaintextTypeToFieldType("bytes0")).toBeUndefined();
-      expect(plaintextTypeToFieldType("bytes33")).toBeUndefined();
-      expect(plaintextTypeToFieldType("euint64")).toBeUndefined();
-      expect(plaintextTypeToFieldType("")).toBeUndefined();
+      expect(parsePlaintextType("uint7")).toBeUndefined();
+      expect(parsePlaintextType("uint512")).toBeUndefined();
+      expect(parsePlaintextType("bytes0")).toBeUndefined();
+      expect(parsePlaintextType("bytes33")).toBeUndefined();
+      expect(parsePlaintextType("euint64")).toBeUndefined();
+      expect(parsePlaintextType("")).toBeUndefined();
     });
   });
 
@@ -971,6 +1001,78 @@ describe("applyFieldFormats", () => {
       // raw value is still available on rawEncryptedValue.
       expect(field.value).toBe("[Encrypted]");
       expect(field.rawEncryptedValue).toBe(HANDLE);
+      expect(field.warning?.code).toBe("DECRYPTION_FAILED");
+    });
+
+    it("reports DECRYPTION_FAILED when the plaintext is too wide for its type", async () => {
+      const result = await applyFieldFormats(
+        encryptedField(FHEVM_UINT64),
+        {},
+        resolvePath,
+        mapArrayLength({}),
+        1,
+        undefined,
+        // 9 significant bytes cannot be a uint64 — rendering it would show a
+        // wildly wrong amount rather than a wrong-looking one.
+        {
+          resolveDecryptedValue: async () => ({
+            value: "0x01ffffffffffffffff",
+          }),
+        },
+      );
+
+      assert(!("warnings" in result));
+      const field = result.fields[0];
+      assert(!isFieldGroup(field));
+      expect(field.value).toBe("[Encrypted Amount]");
+      expect(field.warning?.code).toBe("DECRYPTION_FAILED");
+    });
+
+    it("accepts a zero-padded plaintext whose value fits the type", async () => {
+      const result = await applyFieldFormats(
+        encryptedField(FHEVM_UINT64),
+        {},
+        resolvePath,
+        mapArrayLength({}),
+        1,
+        undefined,
+        // A wallet handing back the full 32-byte ABI word is fine: leading
+        // zeros carry no value for an integer.
+        {
+          resolveDecryptedValue: async () => ({
+            value: `0x${"00".repeat(29)}0f4240`,
+          }),
+        },
+      );
+
+      assert(!("warnings" in result));
+      const field = result.fields[0];
+      assert(!isFieldGroup(field));
+      expect(field.value).toBe("1000000");
+      expect(field.warning).toBeUndefined();
+    });
+
+    it("rejects a bytesN plaintext wider than the declared size", async () => {
+      const result = await applyFieldFormats(
+        encryptedField({
+          scheme: "fhevm",
+          plaintextType: "bytes4",
+          fallbackLabel: "[Encrypted Amount]",
+        }),
+        {},
+        resolvePath,
+        mapArrayLength({}),
+        1,
+        undefined,
+        // Unlike integers, every byte of a bytesN is part of the value, so
+        // leading zeros do not make this fit.
+        { resolveDecryptedValue: async () => ({ value: "0x00cafebabe" }) },
+      );
+
+      assert(!("warnings" in result));
+      const field = result.fields[0];
+      assert(!isFieldGroup(field));
+      expect(field.value).toBe("[Encrypted Amount]");
       expect(field.warning?.code).toBe("DECRYPTION_FAILED");
     });
 

--- a/test/registry-cases/zama/calldata-ConfidentialWrapper.json
+++ b/test/registry-cases/zama/calldata-ConfidentialWrapper.json
@@ -1,0 +1,347 @@
+{
+  "$schema": "../../specs/erc7730-v2.schema.json",
+  "context": {
+    "$id": "ConfidentialWrapper",
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 1,
+          "address": "0xe978F22157048E5DB8E5d07971376e86671672B2"
+        },
+        {
+          "chainId": 1,
+          "address": "0xAe0207C757Aa2B4019Ad96edD0092ddc63EF0c50"
+        },
+        {
+          "chainId": 1,
+          "address": "0xda9396b82634Ea99243cE51258B6A5Ae512D4893"
+        },
+        {
+          "chainId": 1,
+          "address": "0x85dE671c3bec1aDeD752c3Cea943521181C826bc"
+        },
+        {
+          "chainId": 1,
+          "address": "0x80CB147Fd86dC6dEe3Eee7e4Cee33d1397d98071"
+        },
+        {
+          "chainId": 1,
+          "address": "0xa873750ccBafD5ec7Dd13bfD5237d7129832eDD9"
+        },
+        {
+          "chainId": 1,
+          "address": "0x73cc9aF9d6BEFdb3c3fAf8a5E8c05Cb95FdaEEf1"
+        },
+        {
+          "chainId": 1,
+          "address": "0xBA4cFF6ED6F7Cb2A58776dECa4E984b498446762"
+        },
+        {
+          "chainId": 1,
+          "address": "0x66Bf74E96900D1a19c7070D939D124f2F565C458"
+        },
+        {
+          "chainId": 11155111,
+          "address": "0x7c5BF43B851c1dff1a4feE8dB225b87f2C223639"
+        },
+        {
+          "chainId": 11155111,
+          "address": "0x4E7B06D78965594eB5EF5414c357ca21E1554491"
+        },
+        {
+          "chainId": 11155111,
+          "address": "0x46208622DA27d91db4f0393733C8BA082ed83158"
+        },
+        {
+          "chainId": 11155111,
+          "address": "0xaa5612FA27c927a0c7961f5AEFEE5ba3A0F9C891"
+        },
+        {
+          "chainId": 11155111,
+          "address": "0xf2D628d2598aF4eAF94CB76a437Ff86CA78FfbFB"
+        },
+        {
+          "chainId": 11155111,
+          "address": "0xfCE5c7069c5525eF6c8C2b2E35A745bA20a2F7CC"
+        },
+        {
+          "chainId": 11155111,
+          "address": "0xe4FcF848739845BC81Dee1d5352cf3844F0a60C7"
+        },
+        {
+          "chainId": 11155111,
+          "address": "0x167DC962808B32CFFFc7e14B5018c0bE06A3A208"
+        },
+        {
+          "chainId": 11155111,
+          "address": "0x13F7d34A4f0102734F19E3Ff16e068Fe194B28c4"
+        }
+      ]
+    }
+  },
+  "metadata": { "contractName": "ConfidentialWrapper" },
+  "display": {
+    "definitions": {
+      "encryptedAmount": {
+        "label": "Amount",
+        "format": "tokenAmount",
+        "params": { "tokenPath": "@.to" },
+        "encryption": {
+          "scheme": "fhevm",
+          "plaintextType": "uint64",
+          "fallbackLabel": "[Encrypted Amount]"
+        }
+      },
+      "receiver": {
+        "label": "Receiver",
+        "format": "addressName",
+        "params": { "types": ["eoa", "contract"] }
+      },
+      "holder": {
+        "label": "Holder",
+        "format": "addressName",
+        "params": { "types": ["eoa", "contract"] }
+      },
+      "inputProof": { "label": "Encryption proof", "format": "raw" },
+      "decryptionProof": { "label": "Decryption proof", "format": "raw" },
+      "callbackData": { "label": "Callback data", "format": "raw" }
+    },
+    "formats": {
+      "wrap(address to, uint256 amount)": {
+        "$id": "wrap",
+        "intent": "Shield",
+        "interpolatedIntent": "Shield {amount} to {to}",
+        "fields": [
+          { "path": "amount", "label": "Amount", "format": "raw" },
+          { "path": "to", "$ref": "$.display.definitions.receiver" }
+        ]
+      },
+      "unwrap(address from, address to, bytes32 amount)": {
+        "$id": "unwrap",
+        "intent": "Request to unshield",
+        "interpolatedIntent": "Request to unshield from {from} to {to}",
+        "fields": [
+          { "path": "from", "$ref": "$.display.definitions.holder" },
+          { "path": "to", "$ref": "$.display.definitions.receiver" },
+          { "path": "amount", "$ref": "$.display.definitions.encryptedAmount" }
+        ]
+      },
+      "unwrap(address from, address to, bytes32 encryptedAmount, bytes inputProof)": {
+        "$id": "unwrapWithProof",
+        "intent": "Request to unshield",
+        "interpolatedIntent": "Request to unshield from {from} to {to}",
+        "fields": [
+          { "path": "from", "$ref": "$.display.definitions.holder" },
+          { "path": "to", "$ref": "$.display.definitions.receiver" },
+          {
+            "path": "encryptedAmount",
+            "$ref": "$.display.definitions.encryptedAmount"
+          },
+          {
+            "path": "inputProof",
+            "$ref": "$.display.definitions.inputProof",
+            "visible": "never"
+          }
+        ]
+      },
+      "finalizeUnwrap(bytes32 unwrapRequestId, uint64 unwrapAmountCleartext, bytes decryptionProof)": {
+        "$id": "finalizeUnwrap",
+        "intent": "Finalize unshield",
+        "interpolatedIntent": "Finalize unshield of {unwrapAmountCleartext}",
+        "fields": [
+          {
+            "path": "unwrapAmountCleartext",
+            "label": "Amount",
+            "format": "tokenAmount",
+            "params": { "tokenPath": "@.to" }
+          },
+          { "path": "unwrapRequestId", "label": "Request ID", "format": "raw" },
+          {
+            "path": "decryptionProof",
+            "$ref": "$.display.definitions.decryptionProof",
+            "visible": "never"
+          }
+        ]
+      },
+      "confidentialTransfer(address to, bytes32 amount)": {
+        "$id": "cTransfer",
+        "intent": "Confidential transfer",
+        "interpolatedIntent": "Confidential transfer of {amount} to {to}",
+        "fields": [
+          { "path": "amount", "$ref": "$.display.definitions.encryptedAmount" },
+          { "path": "to", "$ref": "$.display.definitions.receiver" }
+        ]
+      },
+      "confidentialTransfer(address to, bytes32 encryptedAmount, bytes inputProof)": {
+        "$id": "cTransferWithProof",
+        "intent": "Confidential transfer",
+        "interpolatedIntent": "Confidential transfer of {encryptedAmount} to {to}",
+        "fields": [
+          {
+            "path": "encryptedAmount",
+            "$ref": "$.display.definitions.encryptedAmount"
+          },
+          { "path": "to", "$ref": "$.display.definitions.receiver" },
+          {
+            "path": "inputProof",
+            "$ref": "$.display.definitions.inputProof",
+            "visible": "never"
+          }
+        ]
+      },
+      "confidentialTransferFrom(address from, address to, bytes32 amount)": {
+        "$id": "cTransferFrom",
+        "intent": "Confidential transfer",
+        "interpolatedIntent": "Confidential transfer of {amount} from {from} to {to}",
+        "fields": [
+          { "path": "amount", "$ref": "$.display.definitions.encryptedAmount" },
+          { "path": "from", "$ref": "$.display.definitions.holder" },
+          { "path": "to", "$ref": "$.display.definitions.receiver" }
+        ]
+      },
+      "confidentialTransferFrom(address from, address to, bytes32 encryptedAmount, bytes inputProof)": {
+        "$id": "cTransferFromWithProof",
+        "intent": "Confidential transfer",
+        "interpolatedIntent": "Confidential transfer of {encryptedAmount} from {from} to {to}",
+        "fields": [
+          {
+            "path": "encryptedAmount",
+            "$ref": "$.display.definitions.encryptedAmount"
+          },
+          { "path": "from", "$ref": "$.display.definitions.holder" },
+          { "path": "to", "$ref": "$.display.definitions.receiver" },
+          {
+            "path": "inputProof",
+            "$ref": "$.display.definitions.inputProof",
+            "visible": "never"
+          }
+        ]
+      },
+      "confidentialTransferAndCall(address to, bytes32 amount, bytes data)": {
+        "$id": "cTransferAndCall",
+        "intent": "Confidential transfer",
+        "interpolatedIntent": "Confidential transfer of {amount} to {to}",
+        "fields": [
+          { "path": "amount", "$ref": "$.display.definitions.encryptedAmount" },
+          { "path": "to", "$ref": "$.display.definitions.receiver" },
+          {
+            "path": "data",
+            "$ref": "$.display.definitions.callbackData",
+            "visible": "never"
+          }
+        ]
+      },
+      "confidentialTransferAndCall(address to, bytes32 encryptedAmount, bytes inputProof, bytes data)": {
+        "$id": "cTransferAndCallWithProof",
+        "intent": "Confidential transfer",
+        "interpolatedIntent": "Confidential transfer of {encryptedAmount} to {to}",
+        "fields": [
+          {
+            "path": "encryptedAmount",
+            "$ref": "$.display.definitions.encryptedAmount"
+          },
+          { "path": "to", "$ref": "$.display.definitions.receiver" },
+          {
+            "path": "inputProof",
+            "$ref": "$.display.definitions.inputProof",
+            "visible": "never"
+          },
+          {
+            "path": "data",
+            "$ref": "$.display.definitions.callbackData",
+            "visible": "never"
+          }
+        ]
+      },
+      "confidentialTransferFromAndCall(address from, address to, bytes32 amount, bytes data)": {
+        "$id": "cTransferFromAndCall",
+        "intent": "Confidential transfer",
+        "interpolatedIntent": "Confidential transfer of {amount} from {from} to {to}",
+        "fields": [
+          { "path": "amount", "$ref": "$.display.definitions.encryptedAmount" },
+          { "path": "from", "$ref": "$.display.definitions.holder" },
+          { "path": "to", "$ref": "$.display.definitions.receiver" },
+          {
+            "path": "data",
+            "$ref": "$.display.definitions.callbackData",
+            "visible": "never"
+          }
+        ]
+      },
+      "confidentialTransferFromAndCall(address from, address to, bytes32 encryptedAmount, bytes inputProof, bytes data)": {
+        "$id": "cTransferFromAndCallWithProof",
+        "intent": "Confidential transfer",
+        "interpolatedIntent": "Confidential transfer of {encryptedAmount} from {from} to {to}",
+        "fields": [
+          {
+            "path": "encryptedAmount",
+            "$ref": "$.display.definitions.encryptedAmount"
+          },
+          { "path": "from", "$ref": "$.display.definitions.holder" },
+          { "path": "to", "$ref": "$.display.definitions.receiver" },
+          {
+            "path": "inputProof",
+            "$ref": "$.display.definitions.inputProof",
+            "visible": "never"
+          },
+          {
+            "path": "data",
+            "$ref": "$.display.definitions.callbackData",
+            "visible": "never"
+          }
+        ]
+      },
+      "setOperator(address operator, uint48 until)": {
+        "$id": "setOperator",
+        "intent": "Authorize operator",
+        "interpolatedIntent": "Authorize operator {operator} until {until}",
+        "fields": [
+          {
+            "path": "operator",
+            "label": "Authorize operator",
+            "format": "addressName",
+            "params": { "types": ["eoa", "contract"] }
+          },
+          {
+            "path": "until",
+            "label": "Authorized until",
+            "format": "date",
+            "params": { "encoding": "timestamp" }
+          }
+        ]
+      },
+      "requestDiscloseEncryptedAmount(bytes32 encryptedAmount)": {
+        "$id": "requestDiscloseEncryptedAmount",
+        "intent": "Request public disclosure",
+        "fields": [
+          {
+            "path": "encryptedAmount",
+            "$ref": "$.display.definitions.encryptedAmount"
+          }
+        ]
+      },
+      "discloseEncryptedAmount(bytes32 encryptedAmount, uint64 cleartextAmount, bytes decryptionProof)": {
+        "$id": "discloseEncryptedAmount",
+        "intent": "Disclose amount publicly",
+        "interpolatedIntent": "Disclose {cleartextAmount} publicly",
+        "fields": [
+          {
+            "path": "cleartextAmount",
+            "label": "Amount",
+            "format": "tokenAmount",
+            "params": { "tokenPath": "@.to" }
+          },
+          {
+            "path": "encryptedAmount",
+            "$ref": "$.display.definitions.encryptedAmount"
+          },
+          {
+            "path": "decryptionProof",
+            "$ref": "$.display.definitions.decryptionProof",
+            "visible": "never"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/registry-cases/zama/zama.spec.ts
+++ b/test/registry-cases/zama/zama.spec.ts
@@ -220,5 +220,123 @@ describe("Zama ConfidentialWrapper", () => {
       // Field-level warnings are not propagated to the model.
       expect(result.warnings).toBeUndefined();
     });
+
+    // =======================================================================
+    // Plaintext encoding edge cases
+    // =======================================================================
+
+    /** Format the same call with a wallet that returns `value`, or declines. */
+    async function formatWithDecrypted(
+      value: string | null,
+    ): Promise<DisplayModel> {
+      return format(
+        {
+          chainId: CHAIN_ID,
+          to: CONTRACT,
+          data: CONFIDENTIAL_TRANSFER_CALLDATA,
+        },
+        buildOpts({
+          resolveToken,
+          resolveLocalName,
+          resolveDecryptedValue: async () =>
+            value === null ? null : { value },
+        }),
+      );
+    }
+
+    /** The Amount field, asserted to be a plain field rather than a group. */
+    function amountFieldOf(result: DisplayModel) {
+      assert(result.fields);
+      expect(result.fields).toHaveLength(2);
+      const field = result.fields[0];
+      assert(!isFieldGroup(field));
+      expect(field.label).toBe("Amount");
+      return field;
+    }
+
+    it("accepts a zero-padded full ABI word for the uint64 plaintext", async () => {
+      // A wallet handing back the whole 32-byte word rather than the minimal
+      // encoding is the realistic case, and leading zeros carry no value.
+      const result = await formatWithDecrypted(
+        "0x" + "00".repeat(29) + "0f4240",
+      );
+
+      const amountField = amountFieldOf(result);
+      expect(amountField.value).toBe("1 cUSDC");
+      expect(amountField.fieldType).toBe("uint");
+      expect(amountField.format).toBe("tokenAmount");
+      expect(amountField.tokenAddress).toBe(
+        toChecksumAddress(hexToBytes(CONTRACT)),
+      );
+      expect(amountField.rawEncryptedValue).toBe(HANDLE);
+      expect(amountField.warning).toBeUndefined();
+      expect(result.interpolatedIntent).toBe(
+        "Confidential transfer of 1 cUSDC to bob.eth",
+      );
+      expect(result.warnings).toBeUndefined();
+    });
+
+    it("reads a top-bit-set plaintext as unsigned, not negative", async () => {
+      // max uint64. Its leading byte has the top bit set, which is what makes a
+      // *signed* type depend on the declared width; `uint64` has no sign bit,
+      // so the full range must render as a positive amount.
+      const result = await formatWithDecrypted("0xffffffffffffffff");
+
+      const amountField = amountFieldOf(result);
+      expect(amountField.value).toBe("18446744073709.551615 cUSDC");
+      expect(amountField.fieldType).toBe("uint");
+      expect(amountField.rawEncryptedValue).toBe(HANDLE);
+      expect(amountField.warning).toBeUndefined();
+      expect(result.interpolatedIntent).toBe(
+        "Confidential transfer of 18446744073709.551615 cUSDC to bob.eth",
+      );
+      expect(result.warnings).toBeUndefined();
+    });
+
+    it("falls back when the plaintext is too wide for the declared uint64", async () => {
+      // Nine significant bytes cannot be a uint64. Rendering it would show a
+      // wildly wrong amount, so it counts as a failed decryption.
+      const result = await formatWithDecrypted("0x01ffffffffffffffff");
+
+      const amountField = amountFieldOf(result);
+      expect(amountField.value).toBe("[Encrypted Amount]");
+      expect(amountField.fieldType).toBe("bytes");
+      expect(amountField.format).toBe("tokenAmount");
+      expect(amountField.warning?.code).toBe("DECRYPTION_FAILED");
+      expect(amountField.rawEncryptedValue).toBe(HANDLE);
+      expect(amountField.tokenAddress).toBeUndefined();
+      expect(result.interpolatedIntent).toBe(
+        "Confidential transfer of [Encrypted Amount] to bob.eth",
+      );
+    });
+
+    it("falls back when the wallet declines to decrypt", async () => {
+      // The provider exists but returns null — no access, or the user declined
+      // the signature. Distinct from having no provider at all, same outcome.
+      const result = await formatWithDecrypted(null);
+
+      const amountField = amountFieldOf(result);
+      expect(amountField.value).toBe("[Encrypted Amount]");
+      expect(amountField.fieldType).toBe("bytes");
+      expect(amountField.format).toBe("tokenAmount");
+      expect(amountField.warning?.code).toBe("DECRYPTION_FAILED");
+      expect(amountField.rawEncryptedValue).toBe(HANDLE);
+      expect(amountField.tokenAddress).toBeUndefined();
+      expect(amountField.embeddedCalldata).toBeUndefined();
+      expect(amountField.rawAddress).toBeUndefined();
+
+      // The receiver is unaffected by the declined decryption.
+      assert(result.fields);
+      const receiverField = result.fields[1];
+      assert(!isFieldGroup(receiverField));
+      expect(receiverField.value).toBe("bob.eth");
+      expect(receiverField.warning).toBeUndefined();
+
+      expect(result.interpolatedIntent).toBe(
+        "Confidential transfer of [Encrypted Amount] to bob.eth",
+      );
+      expect(result.rawCalldataFallback).toBeUndefined();
+      expect(result.warnings).toBeUndefined();
+    });
   });
 });

--- a/test/registry-cases/zama/zama.spec.ts
+++ b/test/registry-cases/zama/zama.spec.ts
@@ -1,0 +1,224 @@
+/**
+ * Tests for the Zama ConfidentialWrapper descriptor:
+ * - confidentialTransfer: an fhevm-encrypted `bytes32` amount handle decrypted
+ *   via the wallet's resolveDecryptedValue callback, then rendered with the
+ *   field's regular tokenAmount format.
+ */
+
+import { describe, it, expect, assert } from "vitest";
+import { format, isFieldGroup } from "../../../src/index.js";
+import type { DisplayModel, ExternalDataProvider } from "../../../src/types.js";
+import { toChecksumAddress, hexToBytes } from "../../../src/utils.js";
+import { buildFilesystemResolverOpts } from "../../utils.js";
+
+describe("Zama ConfidentialWrapper", () => {
+  const CHAIN_ID = 1;
+  // The wrapper is itself the confidential token, so `tokenPath: "@.to"`
+  // resolves the token metadata to this same address.
+  const CONTRACT = "0xe978F22157048E5DB8E5d07971376e86671672B2";
+  const RECEIVER = "0x70997970c51812dc3a010c7d01b50e0d17dc79c8";
+
+  function buildOpts(externalDataProvider?: ExternalDataProvider) {
+    return buildFilesystemResolverOpts(
+      __dirname,
+      {
+        calldataDescriptorFiles: [
+          {
+            chainId: CHAIN_ID,
+            address: CONTRACT,
+            file: "calldata-ConfidentialWrapper.json",
+          },
+        ],
+      },
+      externalDataProvider,
+    );
+  }
+
+  // =========================================================================
+  // confidentialTransfer
+  // =========================================================================
+  describe("confidentialTransfer", () => {
+    // confidentialTransfer(address to, bytes32 amount)
+    //   to     = 0x7099…79C8
+    //   amount = 0xabcd…6789  (an fhevm ciphertext handle, not a value)
+    const HANDLE =
+      "0xabcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+    const CONFIDENTIAL_TRANSFER_CALLDATA =
+      "0x5bebed7e" +
+      "00000000000000000000000070997970c51812dc3a010c7d01b50e0d17dc79c8" +
+      "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+
+    const resolveToken: ExternalDataProvider["resolveToken"] = async (
+      chainId,
+      tokenAddress,
+    ) => {
+      if (chainId === CHAIN_ID && tokenAddress === CONTRACT.toLowerCase()) {
+        return { name: "Confidential USDC", symbol: "cUSDC", decimals: 6 };
+      }
+      return null;
+    };
+
+    const resolveLocalName: ExternalDataProvider["resolveLocalName"] = async (
+      address,
+    ) => {
+      if (address === RECEIVER) {
+        return { name: "bob.eth", typeMatch: true };
+      }
+      return null;
+    };
+
+    it("decrypts the encrypted amount handle and renders it as a token amount", async () => {
+      // The wallet returns the plaintext as hex of its big-endian bytes —
+      // uint64 1000000, which the descriptor's `plaintextType: "uint64"` tells
+      // the library how to re-interpret.
+      const calls: Array<
+        [number, string, { scheme: string; contractAddress?: string }]
+      > = [];
+      const resolveDecryptedValue: ExternalDataProvider["resolveDecryptedValue"] =
+        async (chainId, encryptedValue, params) => {
+          calls.push([chainId, encryptedValue, params]);
+          if (encryptedValue === HANDLE) {
+            return { value: "0x00000000000f4240" };
+          }
+          return null;
+        };
+
+      const opts = buildOpts({
+        resolveToken,
+        resolveLocalName,
+        resolveDecryptedValue,
+      });
+
+      const result: DisplayModel = await format(
+        {
+          chainId: CHAIN_ID,
+          to: CONTRACT,
+          data: CONFIDENTIAL_TRANSFER_CALLDATA,
+        },
+        opts,
+      );
+
+      expect(result.intent).toBe("Confidential transfer");
+
+      // The wallet is handed the raw handle and the contract to run the fhevm
+      // ACL check against (the container's `@.to`).
+      expect(calls).toEqual([
+        [CHAIN_ID, HANDLE, { scheme: "fhevm", contractAddress: CONTRACT }],
+      ]);
+
+      assert(result.fields);
+      expect(result.fields).toHaveLength(2);
+
+      // Field 0: Amount — decrypted handle (1000000, 6 decimals) → "1 cUSDC"
+      const amountField = result.fields[0];
+      assert(!isFieldGroup(amountField));
+      expect(amountField.label).toBe("Amount");
+      expect(amountField.value).toBe("1 cUSDC");
+      expect(amountField.fieldType).toBe("uint");
+      expect(amountField.format).toBe("tokenAmount");
+      expect(amountField.tokenAddress).toBe(
+        toChecksumAddress(hexToBytes(CONTRACT)),
+      );
+      // Reported even though decryption succeeded, so the wallet can surface
+      // the underlying encrypted value alongside the plaintext.
+      expect(amountField.rawEncryptedValue).toBe(HANDLE);
+      expect(amountField.embeddedCalldata).toBeUndefined();
+      expect(amountField.rawAddress).toBeUndefined();
+      expect(amountField.warning).toBeUndefined();
+
+      // Field 1: Receiver (addressName, to → bob.eth)
+      const receiverField = result.fields[1];
+      assert(!isFieldGroup(receiverField));
+      expect(receiverField.label).toBe("Receiver");
+      expect(receiverField.value).toBe("bob.eth");
+      expect(receiverField.fieldType).toBe("address");
+      expect(receiverField.format).toBe("addressName");
+      expect(receiverField.rawAddress).toBe(
+        toChecksumAddress(hexToBytes(RECEIVER)),
+      );
+      expect(receiverField.tokenAddress).toBeUndefined();
+      expect(receiverField.embeddedCalldata).toBeUndefined();
+      expect(receiverField.rawEncryptedValue).toBeUndefined();
+      expect(receiverField.warning).toBeUndefined();
+
+      expect(result.interpolatedIntent).toBe(
+        "Confidential transfer of 1 cUSDC to bob.eth",
+      );
+
+      // Metadata
+      assert(result.metadata);
+      expect(result.metadata.contractName).toBe("ConfidentialWrapper");
+      expect(result.metadata.owner).toBeUndefined();
+      expect(result.metadata.info).toBeUndefined();
+
+      expect(result.rawCalldataFallback).toBeUndefined();
+      expect(result.warnings).toBeUndefined();
+    });
+
+    it("falls back to the descriptor's fallbackLabel when decryption is unavailable", async () => {
+      // No resolveDecryptedValue — the wallet does not support fhevm. Every
+      // other field still formats normally.
+      const opts = buildOpts({ resolveToken, resolveLocalName });
+
+      const result: DisplayModel = await format(
+        {
+          chainId: CHAIN_ID,
+          to: CONTRACT,
+          data: CONFIDENTIAL_TRANSFER_CALLDATA,
+        },
+        opts,
+      );
+
+      expect(result.intent).toBe("Confidential transfer");
+
+      assert(result.fields);
+      expect(result.fields).toHaveLength(2);
+
+      // Field 0: Amount — undecryptable, so the descriptor's fallbackLabel
+      // stands in for the value. The handle is never shown as the value, but
+      // is reported separately for wallets that display it alongside.
+      const amountField = result.fields[0];
+      assert(!isFieldGroup(amountField));
+      expect(amountField.label).toBe("Amount");
+      expect(amountField.value).toBe("[Encrypted Amount]");
+      // Reports the encrypted value's own type — no plaintext was obtained.
+      expect(amountField.fieldType).toBe("bytes");
+      expect(amountField.format).toBe("tokenAmount");
+      expect(amountField.warning?.code).toBe("DECRYPTION_FAILED");
+      expect(amountField.rawEncryptedValue).toBe(HANDLE);
+      // The tokenAmount handler never ran, so no token was resolved.
+      expect(amountField.tokenAddress).toBeUndefined();
+      expect(amountField.embeddedCalldata).toBeUndefined();
+      expect(amountField.rawAddress).toBeUndefined();
+
+      // Field 1: Receiver — unaffected by the failed decryption
+      const receiverField = result.fields[1];
+      assert(!isFieldGroup(receiverField));
+      expect(receiverField.label).toBe("Receiver");
+      expect(receiverField.value).toBe("bob.eth");
+      expect(receiverField.fieldType).toBe("address");
+      expect(receiverField.format).toBe("addressName");
+      expect(receiverField.rawAddress).toBe(
+        toChecksumAddress(hexToBytes(RECEIVER)),
+      );
+      expect(receiverField.tokenAddress).toBeUndefined();
+      expect(receiverField.embeddedCalldata).toBeUndefined();
+      expect(receiverField.rawEncryptedValue).toBeUndefined();
+      expect(receiverField.warning).toBeUndefined();
+
+      expect(result.interpolatedIntent).toBe(
+        "Confidential transfer of [Encrypted Amount] to bob.eth",
+      );
+
+      // Metadata
+      assert(result.metadata);
+      expect(result.metadata.contractName).toBe("ConfidentialWrapper");
+      expect(result.metadata.owner).toBeUndefined();
+      expect(result.metadata.info).toBeUndefined();
+
+      expect(result.rawCalldataFallback).toBeUndefined();
+      // Field-level warnings are not propagated to the model.
+      expect(result.warnings).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
Implements the ERC-7730 [`encryption`](https://eips.ethereum.org/EIPS/eip-7730#encryption-schemes) field annotation. Encrypted field values are decrypted by the wallet, then rendered with the field's regular format — an `fhevm`-encrypted `bytes32` amount becomes `"1 cUSDC"` instead of an opaque handle.

- **New `ExternalDataProvider.resolveDecryptedValue`** — optional, scheme-specific callback. Decryption stays in the wallet because schemes need a live connection, a user signature, and an access-control check. Returns the plaintext as 0x-hex of its big-endian bytes; the library re-interprets those bytes via the descriptor's declared `plaintextType`, so one encoding covers every scheme and type.
- **Field pipeline** (`fields.ts`) — decrypts before visibility evaluation and rendering, so `ifNotIn`/`mustMatch` and the format handler all see the plaintext. Adds `plaintextTypeToFieldType` (canonical Solidity type → `FieldType`), reusing the existing `bytesSliceToFieldType` for the bytes → typed coercion.
- **Graceful fallback** — when decryption is unavailable, the field renders the descriptor's `fallbackLabel` (or a generic `[Encrypted]`) with a `DECRYPTION_FAILED` warning rather than being dropped. The ciphertext is never shown as the value. A malformed `encryption` annotation is instead fatal (`INVALID_DESCRIPTOR`), consistent with the other descriptor checks.
- **New `DisplayField.rawEncryptedValue`** — the raw encrypted value, reported whether or not decryption succeeded. The spec RECOMMENDS wallets show it beside the placeholder.
- **New types** — `DecryptedValueResult`, `DescriptorFieldEncryptionScheme`, and the `DECRYPTION_FAILED` warning code.
- **Tests** — a Zama `ConfidentialWrapper` registry case using the descriptor and calldata from [registry#2595](https://github.com/ethereum/clear-signing-erc7730-registry/pull/2595) (whose own test cases only cover the fallback path), plus unit tests for the coercion and both failure branches.
- **Docs** — new `DECRYPTION.md` covering the scheme-agnostic contract and the `fhevm` (Zama Protocol) integration, the only scheme ERC-7730 currently defines. `src/`, `README.md`, and `GUIDE.md` stay scheme-agnostic.

Also fixes stale `AGENTS.md` claims found along the way: `calldata` was listed as unimplemented (it isn't), and `eip712.ts` was credited with a `resolveFieldType` that doesn't exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)