### PR TITLE
security: pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,9 +15,9 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24
           registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
## Summary

Part of the org-wide action pinning work (argotorg/sourcify#2898). Pins every GitHub Action in this repo to a full-length commit SHA.

Tags are mutable: whoever controls an action's repository can repoint `@v4` at different code at any time, and that code then runs in CI with this repo's secrets. A commit SHA can't be repointed.

Changed **2 workflow file(s)**: ci.yml publish.yml 

Each pin keeps a trailing `# v4.4.0` comment showing the version it resolved to, so the readable version is still there. This matches the convention already used elsewhere in the org (e.g. `mikepenz/action-junit-report`).

## Nothing else changed

Versions are pinned **as they are today** — no upgrades bundled in. Where a workflow sits on an old major (several repos are still on `actions/checkout@v2` / `setup-node@v2`, which run on end-of-life runners), that deserves a separate upgrade PR rather than mixing a behaviour change into a security pin.

## Why now

The `sourcifyeth` org is enabling **Settings → Actions → General → Policies → "Require actions to be pinned to a full-length commit SHA"**. Once that's on, any workflow with an unpinned action fails. This should merge before that flip.

## Keeping pins fresh

Pinning without an updater means these SHAs go stale and stop picking up upstream security fixes. This repo has no Renovate config, so the pins are manual for now. Onboarding Renovate with `pinDigests: true` would keep them maintained — worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)